### PR TITLE
Buffer fix provided

### DIFF
--- a/client/client.py
+++ b/client/client.py
@@ -35,28 +35,6 @@ def refereeThread(conn):
     log = open("log.txt","w")
     stop = True
     while stop:
-        data = s.recv(1024)
-        msg = print(str(data, "utf-8"))
-        print(f"{msg}\n");
-        log.write(f"{msg}\n")
-        pattern = re.compile("GOAL")
-        match = re.search(pattern, msg)
-        if(match):
-            players = re.findall(r'\d+',msg)
-            playerstr = players[0]
-            player = int(playerstr)
-            if player < 5:
-                puntiA += 1
-            else:
-                puntiB += 1
-            log.write(f"punteggio attuale {puntiA}:{puntiB}\n")
-        if(msg == "partitaTerminata\0"):
-            print(f"partita terminata! punteggio finale {puntiA}:{puntiB}\n")
-            sys.exit()
-
-    log = open("log.txt","w")
-    stop = True
-    while stop:
         try:
             # Riceve i dati dal server
             data = s.recv(1024)

--- a/client/client.py
+++ b/client/client.py
@@ -36,8 +36,18 @@ def refereeThread(conn):
     log = open("log.txt","w")
     stop = True
     while stop:
-        data = s.recv(1024)
-        msg = print(str(data, "utf-8"))
+        try:
+            # Riceve i dati dal server
+            data = s.recv(1024)
+            if not data:
+                # Il server ha chiuso la connessione
+                print("Connessione chiusa dal server.")
+                break
+            print("Messaggio ricevuto:", data.decode())
+        except Exception as e:
+            print("Errore nella ricezione dei dati:", e)
+            break
+        msg = str(data, "utf-8")
         print(f"{msg}\n");
         log.write(f"{msg}\n")
         pattern = re.compile("GOAL")
@@ -51,9 +61,9 @@ def refereeThread(conn):
             else:
                 puntiB += 1
             log.write(f"punteggio attuale {puntiA}:{puntiB}\n")
-        if(msg == "partitaTerminata\0"):
+        if(msg == "partitaTerminata"):
             print(f"partita terminata! punteggio finale {puntiA}:{puntiB}\n")
-            sys.exit()
+            stop = False
 
 def invia_giocatore(s,idg,sq):
     comando = f"{sq}{idg}"

--- a/client/client.py
+++ b/client/client.py
@@ -67,10 +67,10 @@ def refereeThread(conn):
                 puntiA += 1
             else:
                 puntiB += 1
-            log.write(f"punteggio attuale {puntiA}:{puntiB}\n")
+            #log.write(f"punteggio attuale {puntiA}:{puntiB}\n")
         if(msg == "partitaTerminata"):
             print(f"partita terminata! punteggio finale {puntiA}:{puntiB}\n")
-            log.write(f"partita terminata! punteggio finale {puntiA}:{puntiB}\n")
+            #log.write(f"partita terminata! punteggio finale {puntiA}:{puntiB}\n")
             stop = False
         else:
             log.write(f"{msg}\n")

--- a/client/client.py
+++ b/client/client.py
@@ -52,7 +52,7 @@ def refereeThread(conn):
         except Exception as e:
             print("Errore nella ricezione dei dati:", e)
             break
-        msg_intero = str(data, "ISO-8859-1")
+        msg_intero = str(data, "utf-8")
         msg_size = lunghezza_stringa_con_terminatore(msg_intero)
         msg = msg_intero[:msg_size]
         print(f"{msg}")
@@ -74,6 +74,7 @@ def refereeThread(conn):
 
 def invia_giocatore(s,idg,sq):
     comando = f"{sq}{idg}"
+    comando += '\0'
     invia_comandi(s,comando)
 
 def invia_comandi(s, comando):

--- a/client/client.py
+++ b/client/client.py
@@ -47,7 +47,8 @@ def refereeThread(conn):
             print("Errore nella ricezione dei dati:", e)
             break
         msg = str(data, "utf-8")
-        print(f"{msg}\n");
+        msg.strip('n')
+        print(f"{msg}")
         log.write(f"{msg}\n")
         pattern = re.compile("GOAL")
         match = re.search(pattern, msg)

--- a/client/client.py
+++ b/client/client.py
@@ -9,6 +9,13 @@ import re
 # richiesta al gateway con un messaggio contenente informazioni delle squadre.
 # l'arbitro manterra' la connessione attiva fino al termine della partita.
 
+def lunghezza_stringa_con_terminatore(stringa):
+    lunghezza = 0
+    for carattere in stringa:
+        if carattere == '\0':
+            break
+        lunghezza += 1
+    return lunghezza
 
 def playerThread(idg, sq, conn):
     try:
@@ -42,12 +49,12 @@ def refereeThread(conn):
                 # Il server ha chiuso la connessione
                 print("Connessione chiusa dal server.")
                 break
-            print("Messaggio ricevuto:", data.decode())
         except Exception as e:
             print("Errore nella ricezione dei dati:", e)
             break
-        msg = str(data, "utf-8")
-        msg.strip('n')
+        msg_intero = str(data, "utf-8")
+        msg_size = lunghezza_stringa_con_terminatore(msg_intero)
+        msg = msg_intero[:msg_size]
         print(f"{msg}")
         log.write(f"{msg}\n")
         pattern = re.compile("GOAL")

--- a/client/client.py
+++ b/client/client.py
@@ -52,7 +52,7 @@ def refereeThread(conn):
         except Exception as e:
             print("Errore nella ricezione dei dati:", e)
             break
-        msg_intero = str(data, "utf-8")
+        msg_intero = str(data, "ISO-8859-1")
         msg_size = lunghezza_stringa_con_terminatore(msg_intero)
         msg = msg_intero[:msg_size]
         print(f"{msg}")

--- a/client/client.py
+++ b/client/client.py
@@ -56,7 +56,7 @@ def refereeThread(conn):
         msg_size = lunghezza_stringa_con_terminatore(msg_intero)
         msg = msg_intero[:msg_size]
         print(f"{msg}")
-        log.write(f"{msg}\n")
+        
         pattern = re.compile("GOAL")
         match = re.search(pattern, msg)
         if(match):
@@ -70,7 +70,10 @@ def refereeThread(conn):
             log.write(f"punteggio attuale {puntiA}:{puntiB}\n")
         if(msg == "partitaTerminata"):
             print(f"partita terminata! punteggio finale {puntiA}:{puntiB}\n")
+            log.write(f"partita terminata! punteggio finale {puntiA}:{puntiB}\n")
             stop = False
+        else:
+            log.write(f"{msg}\n")
 
 def invia_giocatore(s,idg,sq):
     comando = f"{sq}{idg}"

--- a/client/client.py
+++ b/client/client.py
@@ -31,16 +31,28 @@ def refereeThread(conn):
     comando = "sono l'arbitro"
     comando += "\0"
     s.send(comando.encode())
-    data = s.recv(4096)
-    print(f"{data}");
-    pattern = re.compile("GOAL")
-    match = re.search(pattern, data)
-    if(match):
-        player = re.findall(r'\d+',data)
-        if player < 5:
-            puntiA += 1
-        else:
-            puntiB += 1
+
+    log = open("log.txt","w")
+    stop = True
+    while stop:
+        data = s.recv(1024)
+        msg = print(str(data, "utf-8"))
+        print(f"{msg}\n");
+        log.write(f"{msg}\n")
+        pattern = re.compile("GOAL")
+        match = re.search(pattern, msg)
+        if(match):
+            players = re.findall(r'\d+',msg)
+            playerstr = players[0]
+            player = int(playerstr)
+            if player < 5:
+                puntiA += 1
+            else:
+                puntiB += 1
+            log.write(f"punteggio attuale {puntiA}:{puntiB}\n")
+        if(msg == "partitaTerminata\0"):
+            print(f"partita terminata! punteggio finale {puntiA}:{puntiB}\n")
+            sys.exit()
 
     log = open("log.txt","w")
     stop = True

--- a/client/client.py
+++ b/client/client.py
@@ -10,7 +10,6 @@ import re
 # l'arbitro manterra' la connessione attiva fino al termine della partita.
 
 
-
 def playerThread(idg, sq, conn):
     try:
         s = socket.socket()
@@ -32,6 +31,16 @@ def refereeThread(conn):
     comando = "sono l'arbitro"
     comando += "\0"
     s.send(comando.encode())
+    data = s.recv(4096)
+    print(f"{data}");
+    pattern = re.compile("GOAL")
+    match = re.search(pattern, data)
+    if(match):
+        player = re.findall(r'\d+',data)
+        if player < 5:
+            puntiA += 1
+        else:
+            puntiB += 1
 
     log = open("log.txt","w")
     stop = True
@@ -72,7 +81,7 @@ def invia_giocatore(s,idg,sq):
 def invia_comandi(s, comando):
     comando += "\0"
     s.send(comando.encode())
-    
+
 
 def playergen(conn):
     for i in range(10):
@@ -86,9 +95,9 @@ def playergen(conn):
     ref = threading.Thread(target=refereeThread, args=(conn,))
     ref.start()
     ref.join()
-    
-    
-        
+
+
+
 
 if __name__ == '__main__':
     playergen(("127.0.0.1", 8080))

--- a/compose.yaml
+++ b/compose.yaml
@@ -2,6 +2,8 @@
 networks:
     omm:
         name: omm
+        driver: bridge
+
 
 services:
 
@@ -10,7 +12,7 @@ services:
         deploy:
           resources:
             limits:
-              cpus: '0.25'
+              cpus: '0.5'
               memory: 50M
         tty: true
         

--- a/compose.yaml
+++ b/compose.yaml
@@ -10,7 +10,7 @@ services:
         deploy:
           resources:
             limits:
-              cpus: '0.5'
+              cpus: '0.25'
               memory: 50M
         tty: true
         

--- a/compose.yaml
+++ b/compose.yaml
@@ -12,7 +12,7 @@ services:
         deploy:
           resources:
             limits:
-              cpus: '0.5'
+              cpus: '0.75'
               memory: 50M
         tty: true
         

--- a/compose.yaml
+++ b/compose.yaml
@@ -10,7 +10,7 @@ services:
         deploy:
           resources:
             limits:
-              cpus: '0.1'
+              cpus: '0.5'
               memory: 50M
         tty: true
         

--- a/dribbling/dribbling.c
+++ b/dribbling/dribbling.c
@@ -56,10 +56,7 @@ void* service(void* arg) {
 
 	inet_aton(ip, &c_addr.sin_addr);
 
-	printf("service: connecting to referee %s:%d...\n",ip,REFEREEPORT);
-	if (connect(c_fd, (struct sockaddr*)&c_addr, sizeof(c_addr))) {
-		printf("connect() failed to %s:%d\n",ip,REFEREEPORT);
-	}
+	
 
 	printf("service: waiting for player\n");
 	//bisogna capire se avviene un dribbling o un giocatore diventa attivo
@@ -93,6 +90,10 @@ void* service(void* arg) {
 		printf("service: player = %c%d\n", squadre[player], player);
 		chance = rand() % 100;
 		if (chance >= 0 && chance < 35) {
+			printf("service: connecting to referee %s:%d...\n", ip, REFEREEPORT);
+			if (connect(c_fd, (struct sockaddr*)&c_addr, sizeof(c_addr))) {
+				printf("connect() failed to %s:%d\n", ip, REFEREEPORT);
+			}
 			snprintf(buffer, BUFDIM, "d%d%df\0", player,opponent);
 			write(c_fd, buffer, BUFDIM);
 			printf("service: sent message to referee: %s\n", buffer);
@@ -100,6 +101,10 @@ void* service(void* arg) {
 
 		}
 		if (chance >= 35 && chance < 95) {
+			printf("service: connecting to referee %s:%d...\n", ip, REFEREEPORT);
+			if (connect(c_fd, (struct sockaddr*)&c_addr, sizeof(c_addr))) {
+				printf("connect() failed to %s:%d\n", ip, REFEREEPORT);
+			}
 			snprintf(buffer, BUFDIM, "d%d%dy\0",player,opponent);
 			write(c_fd, buffer, BUFDIM);
 			printf("service: sent message to referee: %s\n", buffer);
@@ -180,6 +185,7 @@ int main(int argc, char* argv[]) {
 	}
 
 	while (stop == -1) {
+		printf("main: waiting for player...\n");
 		client = accept(serverSocket, (struct sockaddr*)&clientAddr, &len);
 		printf("main: connection accepted!\n");
 		pthread_create(&player, NULL, service, (void*)&client);

--- a/dribbling/dribbling.c
+++ b/dribbling/dribbling.c
@@ -101,7 +101,10 @@ void* service(void* arg) {
 
 		printf("service: player action\n");
 		player = buffer[0] - '0';
-
+		if (player > 10 || player < 0) {
+			printf("service: wrong player id\n");
+			pthread_exit(NULL);
+		}
 		/*
 			probabilita' fallimento = 35%
 			probabilita' successo = 60%
@@ -111,6 +114,10 @@ void* service(void* arg) {
 		do {
 			opponent = rand() % 10;
 		} while (squadre[opponent] == squadre[player] || stato[opponent] != 'a');
+		if (opponent < 0 || opponent > 10) {
+			printf("service: wrong opponent id\n");
+			pthread_exit(NULL);
+		}
 		printf("service: opponent = %c%d\n", squadre[opponent], opponent);
 		printf("service: player = %c%d\n", squadre[player], player);
 		chance = rand() % 100;

--- a/dribbling/dribbling.c
+++ b/dribbling/dribbling.c
@@ -14,7 +14,7 @@
 #define PORT 8033
 #define BUFDIM 1024
 #define REFEREEPORT 8088
-#define QUEUE 90
+#define QUEUE 360
 
 volatile char squadre[10];
 volatile char stato[10];
@@ -62,6 +62,7 @@ void* service(void* arg) {
 		in attesa con read, quando riceve info esegue codice e risponde con write
 		rimane attivo finche' il giocatore non termina l'evento
 	*/
+	int s_fd = *(int*)arg;
 	printf("service: starting...\n");
 
 	struct hostent* hent;
@@ -69,9 +70,9 @@ void* service(void* arg) {
 	resolve_hostname("gateway", ip, sizeof(ip));
 
 	char buffer[BUFDIM];
-	int s_fd, player, opponent, chance, c_fd;
+	int player, opponent, chance, c_fd;
 	struct sockaddr_in c_addr;
-	s_fd = *(int*)arg;
+	
 
 	c_fd = socket(AF_INET, SOCK_STREAM, 0);
 

--- a/dribbling/dribbling.c
+++ b/dribbling/dribbling.c
@@ -60,10 +60,10 @@ void* service(void* arg) {
 	if (connect(c_fd, (struct sockaddr*)&c_addr, sizeof(c_addr))) {
 		printf("connect() failed to %s:%d\n",ip,REFEREEPORT);
 	}
-	
+
 	printf("service: waiting for player\n");
 	//bisogna capire se avviene un dribbling o un giocatore diventa attivo
-	read(s_fd, buffer, BUFDIM); 
+	read(s_fd, buffer, BUFDIM);
 	if (strcmp(buffer, "partita terminata\0") == 0) {
 		stop = 0;
 		pthread_exit(NULL);
@@ -76,7 +76,7 @@ void* service(void* arg) {
 	}
 
 	if (buffer[0] != 'a') {
-		
+
 		printf("service: player action\n");
 		player = buffer[0] - '0';
 
@@ -85,7 +85,7 @@ void* service(void* arg) {
 			probabilita' successo = 60%
 			probabilita' infortunio = 5%
 		*/
-		
+
 		do {
 			opponent = rand() % 10;
 		} while (squadre[opponent] == squadre[player] || stato[opponent] != 'a');
@@ -97,14 +97,14 @@ void* service(void* arg) {
 			write(c_fd, buffer, BUFDIM);
 			printf("service: sent message to referee: %s\n", buffer);
 			snprintf(buffer, BUFDIM, "f%d\0", opponent);
-			
+
 		}
 		if (chance >= 35 && chance < 95) {
 			snprintf(buffer, BUFDIM, "d%d%dy\0",player,opponent);
 			write(c_fd, buffer, BUFDIM);
 			printf("service: sent message to referee: %s\n", buffer);
 			snprintf(buffer, BUFDIM, "s%d\0", opponent);
-			
+
 		}
 		if (chance >= 95 && chance < 100) {
 			snprintf(buffer, BUFDIM, "i%d\0", opponent);
@@ -159,7 +159,7 @@ int main(int argc, char* argv[]) {
 	char buf[INET_ADDRSTRLEN];
 	inet_ntop(AF_INET, &serverAddr.sin_addr, buf, sizeof(buf));
 	printf("main: Accepting as %s:%d...\n",buf,PORT);
-	
+
 	int i = 0;
 	int j = 0;
 	int id;
@@ -193,6 +193,6 @@ int main(int argc, char* argv[]) {
 	printf("main: sent end match\n");
 
 	close(client);
-	
+
 	return 0;
 }

--- a/gateway/gateway.c
+++ b/gateway/gateway.c
@@ -46,7 +46,7 @@ volatile int tempoFallo[10] = { -1 };
 volatile int tempoInfortunio[10] = { -1 };
 
 //tempo della partita inteso come numero di eventi, a 0 la partita termina.
-volatile int N = 90; 
+volatile int N = 90;
 
 //indica quale giocatore ha il possesso del pallone va da 0 a 9
 volatile int activePlayer = -1;
@@ -106,7 +106,7 @@ void* playerThread(void* arg) {
 
 	struct sockaddr_in addrTiro, addrInfortunio, addrDribbling;
 	int socketTiro, socketInfortunio, socketDribbling;
-	
+
 
 	int chance; //chance di tiro
 
@@ -125,7 +125,7 @@ void* playerThread(void* arg) {
 	printf("player %d thread: 3\n",id);
 	playerCount--;
 	while (N > 0) { //fino a quando non finisce la partita
-		
+
 		pthread_mutex_lock(&pallone); //attende di ricevere possesso del pallone
 		while (activePlayer == id && N > 0) { //controlla se il possesso del pallone e' legale
 
@@ -134,7 +134,7 @@ void* playerThread(void* arg) {
 			printf("Il giocatore %d della squadra %c ha la palla!\n", id, squadra);
 
 			//informo il servizio Dribbling dell'evento
-			
+
 			serviceInit(&socketDribbling, &addrDribbling, ipDribbling, DRIBBLINGPORT);
 			snprintf(buffer, BUFDIM, "%d\0", id);
 			write(socketDribbling, buffer, BUFDIM);
@@ -143,7 +143,7 @@ void* playerThread(void* arg) {
 			printf("player %d thread: dribbling buffer = %s\n", id, buffer);
 			close(socketDribbling);
 			/*
-				formato messaggio dribbling: "x%d" 
+				formato messaggio dribbling: "x%d"
 				(x = s = successo, x = f = fallimento, x = i = infortunio)
 				%d = giocatore avversario
 			*/
@@ -240,7 +240,7 @@ void* playerThread(void* arg) {
 			N--;
 			for (int k = 0; k < 10; k++) {
 				printf("%c%d=%d:%d, ", squadre[k], k, tempoInfortunio[k],tempoFallo[k]);
-				
+
 				if (tempoInfortunio[k] > 0) tempoInfortunio[k]--;
 				else {
 					if (tempoInfortunio[k] == 0) {
@@ -266,13 +266,13 @@ void* playerThread(void* arg) {
 					}
 				}
 			}
-			
-			
+
+
 
 
 			printf("player %d thread: tempo rimanente %d\n", id, N);
 		}
-		
+
 		nDribbling = 0;
 		pthread_mutex_unlock(&pallone);
 	}
@@ -282,7 +282,7 @@ void* playerThread(void* arg) {
 }
 
 /*
-	l'arbitro gestisce le comunicazioni con il thread arbitro lato client. 
+	l'arbitro gestisce le comunicazioni con il thread arbitro lato client.
 	Manda a quest'ultimo gli esiti di ogni evento. In qualche modo deve, quindi,
 	ricevere i risultati delle azioni dai thread giocatori
 */
@@ -308,15 +308,15 @@ void* refereeThread(void* arg) {
 	bind(eventSocket, (struct sockaddr*)&eventAddr, sizeof(eventAddr));
 	listen(eventSocket, 12);
 	len = sizeof(serviceAddr);
-	
+
 	printf("referee thread: server inizializzato\n");
 
 	while (activePlayer == -1);
 	strcpy(buf, "La partita e' cominciata!\n");
 	write(s_fd, buf, BUFDIM);
 
-	printf("referee thread: la partita è cominciata!\n");
-	
+	printf("referee thread: la partita ï¿½ cominciata!\n");
+
 	refServer = 0;
 	while (N > 0) {
 		printf("referee thread: waiting for event\n");
@@ -371,7 +371,7 @@ void* refereeThread(void* arg) {
 
 			case INFORTUNIO:
 				opponent = buf[2] - '0';
-				if (opponent > 9) 
+				if (opponent > 9)
 				{
 					perror("wrong id");
 					exit(EXIT_FAILURE);
@@ -392,9 +392,9 @@ void* refereeThread(void* arg) {
 		printf("referee thread: chiudo la socket dell'evento puntatore: %p\n",&serviceSocket);
 		close(serviceSocket);
 	}
-	
-	
-	
+
+
+
 }
 
 void serviceInit(int* serviceSocket, struct sockaddr_in* serviceAddr, char* ip, int port) {
@@ -463,17 +463,17 @@ int main(int argc, char* argv[]) {
 		exit(1); // Exit the thread if gethostbyname fails
 	}
 	inet_ntop(AF_INET, (void*)hentTiro->h_addr_list[0], ipTiro, 15);
-	
-	
-	
-	
-	
+
+
+
+
+
 
 	//inizializzo i servizi
 	struct sockaddr_in addrTiro, addrInfortunio, addrDribbling;
 	int socketTiro, socketInfortunio, socketDribbling;
 
-	
+
 
 
 	printf("Starting...\n");
@@ -503,7 +503,7 @@ int main(int argc, char* argv[]) {
 		// a zero tutto il resto
 		memset(&(myaddr.sin_zero), '\0', 8);
 	*/
-	
+
 	serverInit(&mySocket, &myaddr, ip, PORT);
 
 	len = sizeof(client);
@@ -511,20 +511,20 @@ int main(int argc, char* argv[]) {
 	bind(mySocket, (struct sockaddr*)&myaddr, sizeof(myaddr));
 	listen(mySocket, 12);
 
-	
-	
+
+
 	/*
 		inet_ntop(AF_INET, &client.sin_addr, buffer, sizeof(buffer));
 		printf("request from client %s\n", buffer);
 	*/
-	
+
 
 
 	inet_ntop(AF_INET, &myaddr.sin_addr, buffer, sizeof(buffer));
 	printf("Accepting as %s with port %d...\n", buffer, PORT);
 
 	//inviamo anche ai servizi le informazioni delle squadre
-	
+
 
 	pthread_mutex_init(&pallone, NULL);
 	pthread_mutex_lock(&pallone); //i giocatori aspettano l'inizio della partita
@@ -546,7 +546,7 @@ int main(int argc, char* argv[]) {
 			interpretarlo. esempio messaggio A3 indicano la squadra (A, B)
 			e id giocatore (0..9)
 		*/
-		
+
 
 		if (buffer[0] == 'A') {
 			player[0] = 'A';
@@ -587,11 +587,11 @@ int main(int argc, char* argv[]) {
 			}
 		}
 	}
-	
+
 	printf("la partita sta per cominciare\n");
 
-	
-	
+
+
 	activePlayer = rand() % 10;
 	while (refServer != 0);
 	while (playerCount > 0);
@@ -614,7 +614,7 @@ int main(int argc, char* argv[]) {
 
 	pthread_join(arbitro, NULL);
 
-	
+
 
 	close(mySocket);
 	close(clientSocket);

--- a/gateway/gateway.c
+++ b/gateway/gateway.c
@@ -602,6 +602,8 @@ int main(int argc, char* argv[]) {
 		pthread_join(squadraA[i],NULL);
 		pthread_join(squadraB[i],NULL);
 	}
+	pthread_join(arbitro, NULL);
+
 	serviceInit(&socketTiro, &addrTiro, ipTiro, TIROPORT);
 	serviceInit(&socketInfortunio, &addrInfortunio, ipInfortunio, INFORTUNIOPORT);
 	serviceInit(&socketDribbling, &addrDribbling, ipDribbling, DRIBBLINGPORT);

--- a/infortunio/infortunio.c
+++ b/infortunio/infortunio.c
@@ -24,13 +24,17 @@ void* service(void *arg){
 
 	struct hostent* hent;
 	hent = gethostbyname("gateway");
+	if (hent == NULL) {
+		perror("gethostbyname");
+		pthread_exit(NULL); // Exit the thread if gethostbyname fails
+	}
 	char ip[40];
 	inet_ntop(AF_INET, (void*)hent->h_addr_list[0], ip, 15);
 
 	read(s_fd, buffer, BUFDIM);
 	if (strcmp(buffer, "partita terminata\0") == 0) {
 		stop = 0;
-		exit(1);
+		pthread_exit(NULL);
 	}
 	printf("service: from player buffer = %s\n", buffer);
 	player = buffer[0] - '0';
@@ -45,7 +49,7 @@ void* service(void *arg){
 	tempoP = (tempoI/2);
 
 	//formato messaggio infortunio: IXXXPXXX\0
-	sprintf(buffer, "I%dP%d\0", tempoI, tempoP);
+	snprintf(buffer, BUFDIM, "I%dP%d\0", tempoI, tempoP);
 	write(s_fd, buffer, BUFDIM);
 	printf("service: to player buffer = %s\n", buffer);
 
@@ -57,7 +61,7 @@ void* service(void *arg){
 		printf("connect() failed to %s:%d\n", ip, REFEREEPORT);
 	}
     
-	sprintf(buffer, "i%d%d\0", player, opponent);
+	snprintf(buffer, BUFDIM, "i%d%d\0", player, opponent);
 	write(client_fd, buffer, BUFDIM);
 	printf("service: to referee buffer = %s\n");
 
@@ -79,6 +83,10 @@ int main(int argc, char* argv[]) {
 	gethostname(hostname, 1023);
 	struct hostent* hent;
 	hent = gethostbyname(hostname);
+	if (hent == NULL) {
+		perror("gethostbyname");
+		exit(1); // Exit the thread if gethostbyname fails
+	}
 	char ip[40];
 	inet_ntop(AF_INET, (void*)hent->h_addr_list[0], ip, 15);
 

--- a/infortunio/infortunio.c
+++ b/infortunio/infortunio.c
@@ -12,7 +12,7 @@
 
 #define PORT 8041
 #define BUFDIM 1024
-#define REFEREEPORT 8088 
+#define REFEREEPORT 8088
 
 volatile char stop = -1;
 
@@ -40,7 +40,7 @@ void* service(void *arg){
 	player = buffer[0] - '0';
 	opponent = buffer[1] - '0';
 
-	
+
 
 	tempoI = rand() % 15;
 	while(tempoI <= 5){
@@ -60,14 +60,14 @@ void* service(void *arg){
     if (connect(client_fd, (struct sockaddr*)&client_addr, sizeof(client_addr))) {
 		printf("connect() failed to %s:%d\n", ip, REFEREEPORT);
 	}
-    
+
 	snprintf(buffer, BUFDIM, "i%d%d\0", player, opponent);
 	write(client_fd, buffer, BUFDIM);
 	printf("service: to referee buffer = %s\n");
 
 	close(client_fd);
 }
- 
+
 int main(int argc, char* argv[]) {
 	time_t t;
 	srand((unsigned)time(&t));
@@ -103,9 +103,9 @@ int main(int argc, char* argv[]) {
 	inet_ntop(AF_INET, &serverAddr.sin_addr, buf, sizeof(buf));
 
 	printf("Accepting as %s:%d...\n", buf, PORT);
-	
+
 	int i = 0, j = 0;
-	
+
 	while (i < 5 || j < 5){
 		client = accept(serverSocket, (struct sockaddr*)&clientAddr, &len);
 		read(client, buffer, BUFDIM);
@@ -120,7 +120,7 @@ int main(int argc, char* argv[]) {
 			j++;
 		}
 	}
-    
+
 	while(stop == -1){
 		printf("main: waiting for player...\n");
 		client = accept(serverSocket, (struct sockaddr*)&clientAddr, &len);

--- a/infortunio/infortunio.c
+++ b/infortunio/infortunio.c
@@ -142,7 +142,6 @@ int main(int argc, char* argv[]) {
 		client = accept(serverSocket, (struct sockaddr*)&clientAddr, &len);
 		printf("main: player found!\n");
 		pthread_create(&player, NULL, service, (void*)&client);
-        pthread_join(player, NULL);
 	}
 
 	close(client);

--- a/infortunio/infortunio.c
+++ b/infortunio/infortunio.c
@@ -57,9 +57,9 @@ void* service(void *arg){
 	resolve_hostname("gateway", ip, sizeof(ip));
 
 	recv(s_fd, buffer, BUFDIM, 0);
-	if (strcmp(buffer, "partita terminata\0") == 0) {
+	if (buffer[0] == 't') {
 		stop = 0;
-		pthread_exit(NULL);
+		exit(1);
 	}
 	printf("service: from player buffer = %s\n", buffer);
 	player = buffer[0] - '0';
@@ -90,7 +90,7 @@ void* service(void *arg){
 	send(client_fd, buffer, BUFDIM, 0);
 	printf("service: to referee buffer = %s\n");
 
-	close(client_fd);
+	//close(client_fd);
 	pthread_mutex_unlock(&synchro);
 }
 

--- a/infortunio/infortunio.c
+++ b/infortunio/infortunio.c
@@ -13,7 +13,7 @@
 #define PORT 8041
 #define BUFDIM 1024
 #define REFEREEPORT 8088
-#define QUEUE 90
+#define QUEUE 360
 
 volatile char stop = -1;
 

--- a/logReferee.txt
+++ b/logReferee.txt
@@ -1,0 +1,2050 @@
+La partita e' cominciata!
+
+il giocatore 2 scarta il giocatore 6
+il giocatore 5 prende la palla da 2
+il giocatore 3 prende la palla da 5
+il giocatore 3 scarta il giocatore 7
+il giocatore 3 e' vittima di un infortunio da parte di 8
+il giocatore 1 e' vittima di un infortunio da parte di 7
+il giocatore 9 prende la palla da 2
+il giocatore 9 scarta il giocatore 4
+il giocatore 9 scarta il giocatore 4
+il giocatore 9 tira... e ha mancato la porta...
+il giocatore 0 scarta il giocatore 6
+il giocatore 0 tira... e ha mancato la porta...
+il giocatore 4 prende la palla da 9
+il giocatore 4 scarta il giocatore 7
+il giocatore 4 scarta il giocatore 6
+il giocatore 4 tira... e ha mancato la porta...
+il giocatore 3 prende la palla da 7
+il giocatore 3 e' vittima di un infortunio da parte di 8
+il giocatore 2 scarta il giocatore 7
+il giocatore 6 prende la palla da 2
+il giocatore 6 scarta il giocatore 2
+il giocatore 6 tira... ed e' GOAL!!!
+il giocatore 4 scarta il giocatore 9
+il giocatore 4 tira... ed e' GOAL!!!
+il giocatore 5 scarta il giocatore 0
+il giocatore 1 prende la palla da 5
+il giocatore 1 scarta il giocatore 6
+il giocatore 1 scarta il giocatore 7
+il giocatore 1 tira... e ha mancato la porta...
+il giocatore 4 prende la palla da 7
+il giocatore 4 scarta il giocatore 9
+il giocatore 6 prende la palla da 4
+il giocatore 6 scarta il giocatore 1
+il giocatore 6 scarta il giocatore 3
+il giocatore 6 tira... ed e' GOAL!!!
+il giocatore 4 scarta il giocatore 8
+il giocatore 9 prende la palla da 4
+il giocatore 9 scarta il giocatore 0
+il giocatore 9 scarta il giocatore 2
+il giocatore 9 tira... e ha mancato la porta...
+il giocatore 2 scarta il giocatore 9
+il giocatore 2 tira... e ha mancato la porta...
+il giocatore 8 scarta il giocatore 0
+il giocatore 8 tira... e ha mancato la porta...
+il giocatore 5 prende la palla da 2
+il giocatore 3 prende la palla da 5
+il giocatore 8 prende la palla da 3
+il giocatore 4 prende la palla da 8
+il giocatore 4 scarta il giocatore 5
+il giocatore 4 e' vittima di un infortunio da parte di 8
+il giocatore 2 e' vittima di un infortunio da parte di 6
+il giocatore 1 scarta il giocatore 7
+il giocatore 1 tira... ed e' GOAL!!!
+il giocatore 9 scarta il giocatore 1
+il giocatore 3 prende la palla da 9
+il giocatore 5 prende la palla da 3
+il giocatore 5 scarta il giocatore 3
+il giocatore 5 scarta il giocatore 3
+il giocatore 5 tira... e ha mancato la porta...
+il giocatore 9 prende la palla da 1
+il giocatore 9 scarta il giocatore 1
+il giocatore 0 prende la palla da 9
+il giocatore 0 scarta il giocatore 9
+il giocatore 0 scarta il giocatore 7
+il giocatore 0 tira... ed e' GOAL!!!
+il giocatore 6 scarta il giocatore 0
+il giocatore 6 scarta il giocatore 0
+il giocatore 6 tira... ed e' GOAL!!!
+il giocatore 0 scarta il giocatore 8
+il giocatore 0 scarta il giocatore 7
+il giocatore 6 prende la palla da 0
+il giocatore 6 scarta il giocatore 4
+il giocatore 6 tira... e ha mancato la porta...
+il giocatore 4 scarta il giocatore 8
+il giocatore 4 scarta il giocatore 8
+il giocatore 7 prende la palla da 4
+il giocatore 3 prende la palla da 7
+il giocatore 3 scarta il giocatore 8
+il giocatore 3 scarta il giocatore 5
+il giocatore 3 scarta il giocatore 5
+il giocatore 3 tira... e ha mancato la porta...
+il giocatore 6 scarta il giocatore 4
+il giocatore 1 prende la palla da 6
+il giocatore 6 prende la palla da 1
+il giocatore 3 prende la palla da 6
+il giocatore 3 scarta il giocatore 8
+il giocatore 8 prende la palla da 3
+il giocatore 8 scarta il giocatore 4
+il giocatore 8 e' vittima di un infortunio da parte di 3
+il giocatore 9 scarta il giocatore 1
+il giocatore 1 prende la palla da 9
+il giocatore 1 scarta il giocatore 7
+il giocatore 1 tira... ed e' GOAL!!!
+il giocatore 0 prende la palla da 6
+il giocatore 0 scarta il giocatore 9
+il giocatore 0 scarta il giocatore 9
+il giocatore 0 scarta il giocatore 5
+il giocatore 0 tira... e ha mancato la porta...
+il giocatore 6 scarta il giocatore 2
+il giocatore 6 tira... ed e' GOAL!!!
+il giocatore 4 scarta il giocatore 8
+il giocatore 4 scarta il giocatore 7
+il giocatore 4 tira... e ha mancato la porta...
+il giocatore 5 scarta il giocatore 4
+il giocatore 5 e' vittima di un infortunio da parte di 4
+il giocatore 7 scarta il giocatore 2
+il giocatore 7 scarta il giocatore 2
+il giocatore 7 scarta il giocatore 3
+il giocatore 7 e' vittima di un infortunio da parte di 3
+il giocatore 0 prende la palla da 8
+il giocatore 9 prende la palla da 0
+il giocatore 9 scarta il giocatore 4
+il giocatore 1 prende la palla da 9
+il giocatore 1 scarta il giocatore 8
+il giocatore 8 prende la palla da 1
+il giocatore 2 prende la palla da 8
+il giocatore 8 prende la palla da 2
+il giocatore 8 scarta il giocatore 2
+il giocatore 8 scarta il giocatore 4
+il giocatore 3 prende la palla da 8
+il giocatore 3 scarta il giocatore 6
+il giocatore 3 scarta il giocatore 7
+il giocatore 3 tira... ed e' GOAL!!!
+il giocatore 8 scarta il giocatore 2
+il giocatore 8 tira... ed e' GOAL!!!
+il giocatore 5 prende la palla da 1
+il giocatore 5 scarta il giocatore 1
+il giocatore 5 tira... e ha mancato la porta...
+il giocatore 3 scarta il giocatore 8
+il giocatore 3 scarta il giocatore 5
+il giocatore 3 tira... e ha mancato la porta...
+il giocatore 1 prende la palla da 5
+il giocatore 8 prende la palla da 1
+il giocatore 1 prende la palla da 8
+il giocatore 1 scarta il giocatore 8
+il giocatore 8 prende la palla da 1
+il giocatore 4 prende la palla da 8
+il giocatore 7 prende la palla da 4
+il giocatore 7 scarta il giocatore 4
+il giocatore 7 scarta il giocatore 3
+il giocatore 7 tira... e ha mancato la porta...
+il giocatore 8 prende la palla da 2
+il giocatore 1 prende la palla da 8
+il giocatore 1 scarta il giocatore 9
+il giocatore 1 scarta il giocatore 7
+il giocatore 8 prende la palla da 1
+il giocatore 8 scarta il giocatore 4
+il giocatore 8 tira... e ha mancato la porta...
+il giocatore 2 scarta il giocatore 9
+il giocatore 2 scarta il giocatore 8
+il giocatore 2 tira... e ha mancato la porta...
+il giocatore 5 scarta il giocatore 2
+il giocatore 5 scarta il giocatore 0
+il giocatore 5 scarta il giocatore 0
+il giocatore 5 tira... e ha mancato la porta...
+il giocatore 0 scarta il giocatore 5
+il giocatore 0 scarta il giocatore 7
+il giocatore 9 prende la palla da 0
+il giocatore 9 e' vittima di un infortunio da parte di 2
+il giocatore 8 scarta il giocatore 4
+il giocatore 3 prende la palla da 8
+il giocatore 3 scarta il giocatore 8
+il giocatore 5 prende la palla da 3
+il giocatore 3 prende la palla da 5
+il giocatore 3 scarta il giocatore 8
+il giocatore 3 tira... e ha mancato la porta...
+il giocatore 8 e' vittima di un infortunio da parte di 0
+il giocatore 4 prende la palla da 6
+il giocatore 5 prende la palla da 4
+il giocatore 5 scarta il giocatore 4
+il giocatore 5 scarta il giocatore 4
+il giocatore 2 prende la palla da 5
+il giocatore 2 scarta il giocatore 7
+il giocatore 2 scarta il giocatore 7
+il giocatore 2 scarta il giocatore 5
+il giocatore 2 tira... e ha mancato la porta...
+il giocatore 9 scarta il giocatore 1
+il giocatore 2 prende la palla da 9
+il giocatore 2 scarta il giocatore 7
+il giocatore 2 e' vittima di un infortunio da parte di 8
+il giocatore 6 prende la palla da 3
+il giocatore 6 scarta il giocatore 3
+il giocatore 1 prende la palla da 6
+il giocatore 1 scarta il giocatore 9
+il giocatore 6 prende la palla da 1
+il giocatore 3 prende la palla da 6
+il giocatore 3 scarta il giocatore 5
+il giocatore 3 tira... e ha mancato la porta...
+il giocatore 9 scarta il giocatore 3
+il giocatore 0 prende la palla da 9
+il giocatore 0 scarta il giocatore 6
+il giocatore 7 prende la palla da 0
+il giocatore 7 e' vittima di un infortunio da parte di 1
+il giocatore 3 prende la palla da 9
+il giocatore 3 e' vittima di un infortunio da parte di 6
+il giocatore 0 scarta il giocatore 5
+il giocatore 0 tira... e ha mancato la porta...
+il giocatore 0 prende la palla da 8
+il giocatore 8 prende la palla da 0
+il giocatore 8 scarta il giocatore 4
+il giocatore 8 scarta il giocatore 0
+il giocatore 8 scarta il giocatore 2
+il giocatore 8 tira... ed e' GOAL!!!
+il giocatore 2 scarta il giocatore 6
+il giocatore 2 tira... e ha mancato la porta...
+il giocatore 1 prende la palla da 6
+il giocatore 1 scarta il giocatore 9
+il giocatore 1 scarta il giocatore 5
+il giocatore 1 scarta il giocatore 6
+il giocatore 1 tira... e ha mancato la porta...
+il giocatore 8 scarta il giocatore 3
+il giocatore 8 e' vittima di un infortunio da parte di 1
+il giocatore 7 scarta il giocatore 4
+il giocatore 7 scarta il giocatore 2
+il giocatore 7 tira... e ha mancato la porta...
+il giocatore 3 scarta il giocatore 6
+il giocatore 3 scarta il giocatore 6
+il giocatore 3 tira... e ha mancato la porta...
+il giocatore 5 scarta il giocatore 2
+il giocatore 5 tira... ed e' GOAL!!!
+il giocatore 4 scarta il giocatore 6
+il giocatore 4 tira... ed e' GOAL!!!
+il giocatore 0 prende la palla da 5
+il giocatore 0 scarta il giocatore 6
+il giocatore 0 tira... ed e' GOAL!!!
+il giocatore 6 scarta il giocatore 2
+il giocatore 3 prende la palla da 6
+il giocatore 6 prende la palla da 3
+il giocatore 6 scarta il giocatore 1
+il giocatore 0 prende la palla da 6
+il giocatore 0 scarta il giocatore 7
+il giocatore 7 prende la palla da 0
+il giocatore 7 scarta il giocatore 4
+il giocatore 7 tira... e ha mancato la porta...
+il giocatore 8 prende la palla da 3
+il giocatore 3 prende la palla da 8
+il giocatore 3 scarta il giocatore 9
+il giocatore 3 scarta il giocatore 6
+il giocatore 3 scarta il giocatore 7
+il giocatore 3 tira... ed e' GOAL!!!
+il giocatore 8 scarta il giocatore 0
+il giocatore 8 scarta il giocatore 4
+il giocatore 8 tira... e ha mancato la porta...
+il giocatore 7 prende la palla da 3
+il giocatore 7 scarta il giocatore 3
+il giocatore 7 tira... ed e' GOAL!!!
+il giocatore 9 prende la palla da 1
+il giocatore 0 prende la palla da 9
+il giocatore 6 prende la palla da 0
+il giocatore 6 scarta il giocatore 3
+il giocatore 6 scarta il giocatore 2
+il giocatore 6 tira... e ha mancato la porta...
+il giocatore 1 scarta il giocatore 9
+il giocatore 1 scarta il giocatore 9
+il giocatore 1 tira... e ha mancato la porta...
+il giocatore 0 prende la palla da 7
+il giocatore 0 scarta il giocatore 8
+il giocatore 0 scarta il giocatore 8
+il giocatore 0 scarta il giocatore 8
+il giocatore 0 tira... e ha mancato la porta...
+il giocatore 1 prende la palla da 8
+il giocatore 1 scarta il giocatore 9
+il giocatore 6 prende la palla da 1
+il giocatore 0 prende la palla da 6
+il giocatore 0 e' vittima di un infortunio da parte di 5
+il giocatore 4 scarta il giocatore 7
+il giocatore 9 prende la palla da 4
+il giocatore 4 prende la palla da 9
+il giocatore 4 scarta il giocatore 7
+il giocatore 4 scarta il giocatore 7
+il giocatore 4 tira... ed e' GOAL!!!
+il giocatore 8 scarta il giocatore 4
+il giocatore 8 scarta il giocatore 2
+il giocatore 8 tira... ed e' GOAL!!!
+il giocatore 8 prende la palla da 4
+il giocatore 1 prende la palla da 8
+il giocatore 1 scarta il giocatore 9
+il giocatore 9 prende la palla da 1
+il giocatore 9 scarta il giocatore 1
+il giocatore 1 prende la palla da 9
+il giocatore 1 scarta il giocatore 9
+il giocatore 1 tira... ed e' GOAL!!!
+il giocatore 0 prende la palla da 8
+il giocatore 0 scarta il giocatore 6
+il giocatore 0 tira... e ha mancato la porta...
+il giocatore 0 prende la palla da 7
+il giocatore 0 scarta il giocatore 6
+il giocatore 0 e' vittima di un infortunio da parte di 5
+il giocatore 8 prende la palla da 4
+il giocatore 1 prende la palla da 8
+il giocatore 1 scarta il giocatore 8
+il giocatore 1 tira... ed e' GOAL!!!
+il giocatore 6 scarta il giocatore 4
+il giocatore 1 prende la palla da 6
+il giocatore 1 scarta il giocatore 7
+il giocatore 1 scarta il giocatore 5
+il giocatore 1 tira... e ha mancato la porta...
+il giocatore 5 scarta il giocatore 1
+il giocatore 3 prende la palla da 5
+il giocatore 3 scarta il giocatore 5
+il giocatore 3 scarta il giocatore 6
+il giocatore 3 tira... e ha mancato la porta...
+il giocatore 6 scarta il giocatore 1
+il giocatore 6 scarta il giocatore 4
+il giocatore 6 tira... ed e' GOAL!!!
+il giocatore 4 e' vittima di un infortunio da parte di 8
+il giocatore 0 scarta il giocatore 7
+il giocatore 7 prende la palla da 0
+il giocatore 3 prende la palla da 7
+il giocatore 9 prende la palla da 3
+il giocatore 2 prende la palla da 9
+il giocatore 5 prende la palla da 2
+il giocatore 1 prende la palla da 5
+il giocatore 8 prende la palla da 1
+il giocatore 8 scarta il giocatore 0
+il giocatore 1 prende la palla da 8
+il giocatore 5 prende la palla da 1
+il giocatore 0 prende la palla da 5
+il giocatore 0 scarta il giocatore 6
+il giocatore 0 tira... e ha mancato la porta...
+il giocatore 5 scarta il giocatore 2
+il giocatore 5 tira... e ha mancato la porta...
+il giocatore 4 scarta il giocatore 7
+il giocatore 9 prende la palla da 4
+il giocatore 9 scarta il giocatore 2
+il giocatore 9 tira... ed e' GOAL!!!
+il giocatore 7 prende la palla da 1
+il giocatore 7 scarta il giocatore 2
+il giocatore 2 prende la palla da 7
+il giocatore 2 scarta il giocatore 9
+il giocatore 7 prende la palla da 2
+il giocatore 7 scarta il giocatore 2
+il giocatore 7 scarta il giocatore 3
+il giocatore 7 tira... ed e' GOAL!!!
+il giocatore 5 prende la palla da 2
+il giocatore 5 scarta il giocatore 2
+il giocatore 5 scarta il giocatore 0
+il giocatore 5 e' vittima di un infortunio da parte di 2
+il giocatore 8 scarta il giocatore 1
+il giocatore 8 scarta il giocatore 0
+il giocatore 8 tira... ed e' GOAL!!!
+il giocatore 9 prende la palla da 4
+il giocatore 9 scarta il giocatore 3
+il giocatore 9 scarta il giocatore 3
+il giocatore 1 prende la palla da 9
+il giocatore 1 scarta il giocatore 6
+il giocatore 9 prende la palla da 1
+il giocatore 9 scarta il giocatore 3
+il giocatore 9 tira... e ha mancato la porta...
+il giocatore 0 scarta il giocatore 5
+il giocatore 0 scarta il giocatore 7
+il giocatore 5 prende la palla da 0
+il giocatore 5 e' vittima di un infortunio da parte di 0
+il giocatore 6 scarta il giocatore 2
+il giocatore 6 scarta il giocatore 4
+il giocatore 4 prende la palla da 6
+il giocatore 4 scarta il giocatore 9
+il giocatore 4 e' vittima di un infortunio da parte di 9
+il giocatore 3 scarta il giocatore 7
+il giocatore 3 scarta il giocatore 6
+il giocatore 3 tira... ed e' GOAL!!!
+il giocatore 7 scarta il giocatore 1
+il giocatore 7 tira... ed e' GOAL!!!
+il giocatore 6 prende la palla da 2
+il giocatore 0 prende la palla da 6
+il giocatore 0 scarta il giocatore 6
+il giocatore 0 tira... e ha mancato la porta...
+il giocatore 6 scarta il giocatore 0
+il giocatore 6 scarta il giocatore 2
+il giocatore 6 tira... ed e' GOAL!!!
+il giocatore 3 scarta il giocatore 8
+il giocatore 3 tira... ed e' GOAL!!!
+il giocatore 3 prende la palla da 6
+il giocatore 3 scarta il giocatore 7
+il giocatore 6 prende la palla da 3
+il giocatore 6 scarta il giocatore 0
+il giocatore 6 scarta il giocatore 1
+il giocatore 6 tira... e ha mancato la porta...
+il giocatore 1 scarta il giocatore 5
+il giocatore 1 scarta il giocatore 9
+il giocatore 1 scarta il giocatore 9
+il giocatore 1 scarta il giocatore 9
+il giocatore 1 tira... ed e' GOAL!!!
+il giocatore 8 scarta il giocatore 2
+il giocatore 2 prende la palla da 8
+il giocatore 6 prende la palla da 2
+il giocatore 1 prende la palla da 6
+il giocatore 1 scarta il giocatore 8
+il giocatore 1 tira... ed e' GOAL!!!
+il giocatore 8 scarta il giocatore 1
+il giocatore 8 e' vittima di un infortunio da parte di 4
+il giocatore 5 scarta il giocatore 0
+il giocatore 5 scarta il giocatore 3
+il giocatore 5 tira... e ha mancato la porta...
+il giocatore 1 scarta il giocatore 7
+il giocatore 1 scarta il giocatore 6
+il giocatore 1 scarta il giocatore 6
+il giocatore 1 tira... ed e' GOAL!!!
+il giocatore 9 scarta il giocatore 4
+il giocatore 9 tira... ed e' GOAL!!!
+il giocatore 3 scarta il giocatore 8
+il giocatore 9 prende la palla da 3
+il giocatore 4 prende la palla da 9
+il giocatore 4 scarta il giocatore 8
+il giocatore 4 scarta il giocatore 6
+il giocatore 4 scarta il giocatore 7
+il giocatore 4 tira... e ha mancato la porta...
+il giocatore 5 scarta il giocatore 4
+il giocatore 5 tira... ed e' GOAL!!!
+il giocatore 1 scarta il giocatore 7
+il giocatore 1 scarta il giocatore 7
+il giocatore 1 scarta il giocatore 6
+il giocatore 1 tira... ed e' GOAL!!!
+il giocatore 8 scarta il giocatore 2
+il giocatore 8 scarta il giocatore 2
+il giocatore 8 scarta il giocatore 2
+il giocatore 8 tira... e ha mancato la porta...
+il giocatore 4 scarta il giocatore 8
+il giocatore 4 tira... e ha mancato la porta...
+il giocatore 9 scarta il giocatore 3
+il giocatore 9 tira... e ha mancato la porta...
+il giocatore 7 prende la palla da 0
+il giocatore 4 prende la palla da 7
+il giocatore 9 prende la palla da 4
+il giocatore 4 prende la palla da 9
+il giocatore 5 prende la palla da 4
+il giocatore 0 prende la palla da 5
+il giocatore 0 scarta il giocatore 6
+il giocatore 0 scarta il giocatore 8
+il giocatore 0 scarta il giocatore 7
+il giocatore 0 tira... e ha mancato la porta...
+il giocatore 6 scarta il giocatore 2
+il giocatore 6 tira... ed e' GOAL!!!
+il giocatore 2 scarta il giocatore 9
+il giocatore 2 scarta il giocatore 8
+il giocatore 2 scarta il giocatore 7
+il giocatore 7 prende la palla da 2
+il giocatore 0 prende la palla da 7
+il giocatore 0 scarta il giocatore 8
+il giocatore 0 tira... e ha mancato la porta...
+il giocatore 4 prende la palla da 8
+il giocatore 6 prende la palla da 4
+il giocatore 6 scarta il giocatore 0
+il giocatore 6 scarta il giocatore 0
+il giocatore 6 tira... ed e' GOAL!!!
+il giocatore 2 scarta il giocatore 6
+il giocatore 2 tira... ed e' GOAL!!!
+il giocatore 3 prende la palla da 8
+il giocatore 3 scarta il giocatore 7
+il giocatore 8 prende la palla da 3
+il giocatore 8 scarta il giocatore 2
+il giocatore 8 scarta il giocatore 0
+il giocatore 8 tira... ed e' GOAL!!!
+il giocatore 4 scarta il giocatore 8
+il giocatore 6 prende la palla da 4
+il giocatore 1 prende la palla da 6
+il giocatore 1 scarta il giocatore 7
+il giocatore 1 tira... e ha mancato la porta...
+il giocatore 5 scarta il giocatore 1
+il giocatore 5 scarta il giocatore 4
+il giocatore 5 scarta il giocatore 4
+il giocatore 5 tira... ed e' GOAL!!!
+il giocatore 3 scarta il giocatore 9
+il giocatore 3 scarta il giocatore 6
+il giocatore 3 scarta il giocatore 6
+il giocatore 3 tira... e ha mancato la porta...
+il giocatore 8 scarta il giocatore 4
+il giocatore 8 tira... ed e' GOAL!!!
+il giocatore 5 prende la palla da 0
+il giocatore 5 scarta il giocatore 3
+il giocatore 5 tira... e ha mancato la porta...
+il giocatore 4 scarta il giocatore 5
+il giocatore 4 scarta il giocatore 7
+il giocatore 4 scarta il giocatore 5
+il giocatore 4 tira... e ha mancato la porta...
+il giocatore 3 prende la palla da 9
+il giocatore 9 prende la palla da 3
+il giocatore 9 scarta il giocatore 4
+il giocatore 9 scarta il giocatore 2
+il giocatore 4 prende la palla da 9
+il giocatore 9 prende la palla da 4
+il giocatore 9 scarta il giocatore 4
+il giocatore 1 prende la palla da 9
+il giocatore 1 scarta il giocatore 8
+il giocatore 1 tira... ed e' GOAL!!!
+il giocatore 7 scarta il giocatore 4
+il giocatore 7 scarta il giocatore 4
+il giocatore 7 e' vittima di un infortunio da parte di 4
+il giocatore 5 scarta il giocatore 3
+il giocatore 5 scarta il giocatore 3
+il giocatore 5 tira... e ha mancato la porta...
+il giocatore 1 scarta il giocatore 8
+il giocatore 1 tira... ed e' GOAL!!!
+il giocatore 3 prende la palla da 5
+il giocatore 9 prende la palla da 3
+il giocatore 0 prende la palla da 9
+il giocatore 0 scarta il giocatore 8
+il giocatore 0 scarta il giocatore 5
+il giocatore 0 tira... e ha mancato la porta...
+il giocatore 6 scarta il giocatore 0
+il giocatore 6 tira... ed e' GOAL!!!
+il giocatore 2 scarta il giocatore 9
+il giocatore 2 scarta il giocatore 9
+il giocatore 2 scarta il giocatore 8
+il giocatore 2 tira... e ha mancato la porta...
+il giocatore 8 scarta il giocatore 2
+il giocatore 8 tira... e ha mancato la porta...
+il giocatore 4 scarta il giocatore 9
+il giocatore 8 prende la palla da 4
+il giocatore 8 scarta il giocatore 2
+il giocatore 4 prende la palla da 8
+il giocatore 4 scarta il giocatore 8
+il giocatore 4 tira... e ha mancato la porta...
+il giocatore 8 scarta il giocatore 2
+il giocatore 8 scarta il giocatore 4
+il giocatore 8 scarta il giocatore 2
+il giocatore 8 tira... ed e' GOAL!!!
+il giocatore 3 scarta il giocatore 7
+il giocatore 3 scarta il giocatore 7
+il giocatore 3 scarta il giocatore 9
+il giocatore 3 tira... ed e' GOAL!!!
+il giocatore 6 scarta il giocatore 0
+il giocatore 6 tira... e ha mancato la porta...
+il giocatore 4 scarta il giocatore 9
+il giocatore 4 scarta il giocatore 8
+il giocatore 4 tira... ed e' GOAL!!!
+il giocatore 1 prende la palla da 8
+il giocatore 6 prende la palla da 1
+il giocatore 3 prende la palla da 6
+il giocatore 3 scarta il giocatore 9
+il giocatore 5 prende la palla da 3
+il giocatore 3 prende la palla da 5
+il giocatore 3 scarta il giocatore 5
+il giocatore 3 scarta il giocatore 8
+il giocatore 3 tira... ed e' GOAL!!!
+il giocatore 8 scarta il giocatore 3
+il giocatore 8 scarta il giocatore 1
+il giocatore 8 tira... e ha mancato la porta...
+il giocatore 8 prende la palla da 3
+il giocatore 0 prende la palla da 8
+il giocatore 0 scarta il giocatore 9
+il giocatore 0 scarta il giocatore 5
+il giocatore 0 scarta il giocatore 5
+il giocatore 0 tira... ed e' GOAL!!!
+il giocatore 6 scarta il giocatore 1
+il giocatore 6 tira... ed e' GOAL!!!
+il giocatore 8 prende la palla da 1
+il giocatore 3 prende la palla da 8
+il giocatore 9 prende la palla da 3
+il giocatore 4 prende la palla da 9
+il giocatore 4 scarta il giocatore 9
+il giocatore 4 scarta il giocatore 5
+il giocatore 4 tira... e ha mancato la porta...
+il giocatore 9 scarta il giocatore 1
+il giocatore 9 tira... ed e' GOAL!!!
+il giocatore 6 prende la palla da 3
+il giocatore 2 prende la palla da 6
+il giocatore 2 e' vittima di un infortunio da parte di 9
+il giocatore 3 scarta il giocatore 5
+il giocatore 6 prende la palla da 3
+il giocatore 6 e' vittima di un infortunio da parte di 4
+il giocatore 3 prende la palla da 7
+il giocatore 3 scarta il giocatore 5
+il giocatore 3 scarta il giocatore 8
+il giocatore 3 tira... ed e' GOAL!!!
+il giocatore 3 prende la palla da 7
+il giocatore 3 scarta il giocatore 8
+il giocatore 9 prende la palla da 3
+il giocatore 9 scarta il giocatore 3
+il giocatore 9 tira... ed e' GOAL!!!
+il giocatore 7 prende la palla da 1
+il giocatore 2 prende la palla da 7
+il giocatore 2 e' vittima di un infortunio da parte di 5
+il giocatore 0 scarta il giocatore 6
+il giocatore 9 prende la palla da 0
+il giocatore 9 scarta il giocatore 0
+il giocatore 0 prende la palla da 9
+il giocatore 8 prende la palla da 0
+il giocatore 3 prende la palla da 8
+il giocatore 3 scarta il giocatore 9
+il giocatore 3 scarta il giocatore 5
+il giocatore 3 scarta il giocatore 7
+il giocatore 3 tira... ed e' GOAL!!!
+il giocatore 3 prende la palla da 8
+il giocatore 3 scarta il giocatore 7
+il giocatore 3 tira... e ha mancato la porta...
+il giocatore 9 scarta il giocatore 3
+il giocatore 9 scarta il giocatore 1
+il giocatore 9 tira... ed e' GOAL!!!
+il giocatore 4 scarta il giocatore 7
+il giocatore 4 tira... e ha mancato la porta...
+il giocatore 9 scarta il giocatore 4
+il giocatore 9 tira... e ha mancato la porta...
+il giocatore 5 prende la palla da 0
+il giocatore 5 scarta il giocatore 3
+il giocatore 5 tira... e ha mancato la porta...
+il giocatore 2 scarta il giocatore 9
+il giocatore 2 tira... e ha mancato la porta...
+il giocatore 6 scarta il giocatore 1
+il giocatore 6 scarta il giocatore 4
+il giocatore 6 tira... ed e' GOAL!!!
+il giocatore 9 prende la palla da 3
+il giocatore 9 scarta il giocatore 4
+il giocatore 0 prende la palla da 9
+il giocatore 0 e' vittima di un infortunio da parte di 9
+il giocatore 3 scarta il giocatore 8
+il giocatore 3 scarta il giocatore 6
+il giocatore 3 scarta il giocatore 5
+il giocatore 3 scarta il giocatore 7
+il giocatore 3 tira... ed e' GOAL!!!
+il giocatore 1 prende la palla da 7
+il giocatore 1 scarta il giocatore 8
+il giocatore 1 tira... e ha mancato la porta...
+il giocatore 5 scarta il giocatore 3
+il giocatore 5 scarta il giocatore 4
+il giocatore 2 prende la palla da 5
+il giocatore 7 prende la palla da 2
+il giocatore 7 scarta il giocatore 2
+il giocatore 7 scarta il giocatore 4
+il giocatore 7 tira... e ha mancato la porta...
+il giocatore 3 scarta il giocatore 7
+il giocatore 7 prende la palla da 3
+il giocatore 7 scarta il giocatore 0
+il giocatore 7 scarta il giocatore 3
+il giocatore 7 scarta il giocatore 0
+il giocatore 7 tira... ed e' GOAL!!!
+il giocatore 8 prende la palla da 1
+il giocatore 0 prende la palla da 8
+il giocatore 6 prende la palla da 0
+il giocatore 3 prende la palla da 6
+il giocatore 8 prende la palla da 3
+il giocatore 8 scarta il giocatore 0
+il giocatore 8 tira... ed e' GOAL!!!
+il giocatore 4 scarta il giocatore 7
+il giocatore 6 prende la palla da 4
+il giocatore 6 scarta il giocatore 4
+il giocatore 6 scarta il giocatore 4
+il giocatore 6 scarta il giocatore 2
+il giocatore 3 prende la palla da 6
+il giocatore 7 prende la palla da 3
+il giocatore 7 scarta il giocatore 4
+il giocatore 7 scarta il giocatore 4
+il giocatore 7 tira... ed e' GOAL!!!
+il giocatore 4 scarta il giocatore 7
+il giocatore 5 prende la palla da 4
+il giocatore 2 prende la palla da 5
+il giocatore 8 prende la palla da 2
+il giocatore 8 scarta il giocatore 4
+il giocatore 8 tira... ed e' GOAL!!!
+il giocatore 8 prende la palla da 2
+il giocatore 8 scarta il giocatore 4
+il giocatore 8 tira... ed e' GOAL!!!
+il giocatore 5 prende la palla da 4
+il giocatore 0 prende la palla da 5
+il giocatore 7 prende la palla da 0
+il giocatore 0 prende la palla da 7
+il giocatore 0 e' vittima di un infortunio da parte di 6
+il giocatore 2 scarta il giocatore 5
+il giocatore 2 scarta il giocatore 9
+il giocatore 2 tira... ed e' GOAL!!!
+il giocatore 9 scarta il giocatore 3
+il giocatore 9 tira... ed e' GOAL!!!
+il giocatore 7 prende la palla da 2
+il giocatore 7 scarta il giocatore 1
+il giocatore 7 tira... e ha mancato la porta...
+il giocatore 6 prende la palla da 3
+il giocatore 6 scarta il giocatore 1
+il giocatore 6 scarta il giocatore 3
+il giocatore 6 scarta il giocatore 2
+il giocatore 6 tira... ed e' GOAL!!!
+il giocatore 6 prende la palla da 1
+il giocatore 6 scarta il giocatore 4
+il giocatore 6 scarta il giocatore 1
+il giocatore 3 prende la palla da 6
+il giocatore 3 scarta il giocatore 8
+il giocatore 3 tira... ed e' GOAL!!!
+il giocatore 6 scarta il giocatore 3
+il giocatore 4 prende la palla da 6
+il giocatore 5 prende la palla da 4
+il giocatore 5 scarta il giocatore 4
+il giocatore 5 tira... ed e' GOAL!!!
+il giocatore 0 scarta il giocatore 6
+il giocatore 0 scarta il giocatore 6
+il giocatore 0 tira... ed e' GOAL!!!
+il giocatore 0 prende la palla da 7
+il giocatore 7 prende la palla da 0
+il giocatore 7 scarta il giocatore 2
+il giocatore 2 prende la palla da 7
+il giocatore 2 scarta il giocatore 5
+il giocatore 2 scarta il giocatore 5
+il giocatore 2 tira... ed e' GOAL!!!
+il giocatore 4 prende la palla da 9
+il giocatore 4 e' vittima di un infortunio da parte di 9
+il giocatore 7 prende la palla da 2
+il giocatore 7 scarta il giocatore 0
+il giocatore 7 tira... ed e' GOAL!!!
+il giocatore 8 prende la palla da 3
+il giocatore 0 prende la palla da 8
+il giocatore 0 scarta il giocatore 9
+il giocatore 0 scarta il giocatore 7
+il giocatore 0 tira... e ha mancato la porta...
+il giocatore 8 scarta il giocatore 2
+il giocatore 8 e' vittima di un infortunio da parte di 1
+il giocatore 4 prende la palla da 7
+il giocatore 7 prende la palla da 4
+il giocatore 7 scarta il giocatore 0
+il giocatore 7 scarta il giocatore 3
+il giocatore 7 e' vittima di un infortunio da parte di 2
+il giocatore 5 scarta il giocatore 0
+il giocatore 5 scarta il giocatore 4
+il giocatore 5 tira... e ha mancato la porta...
+il giocatore 6 prende la palla da 4
+il giocatore 6 scarta il giocatore 3
+il giocatore 6 tira... ed e' GOAL!!!
+il giocatore 3 scarta il giocatore 5
+il giocatore 9 prende la palla da 3
+il giocatore 9 scarta il giocatore 3
+il giocatore 9 scarta il giocatore 3
+il giocatore 9 tira... e ha mancato la porta...
+il giocatore 4 e' vittima di un infortunio da parte di 6
+il giocatore 0 scarta il giocatore 9
+il giocatore 0 scarta il giocatore 8
+il giocatore 0 scarta il giocatore 8
+il giocatore 0 tira... ed e' GOAL!!!
+il giocatore 3 prende la palla da 7
+il giocatore 3 scarta il giocatore 5
+il giocatore 3 scarta il giocatore 7
+il giocatore 3 tira... ed e' GOAL!!!
+il giocatore 3 prende la palla da 9
+il giocatore 3 scarta il giocatore 6
+il giocatore 9 prende la palla da 3
+il giocatore 9 scarta il giocatore 2
+il giocatore 9 e' vittima di un infortunio da parte di 1
+il giocatore 5 e' vittima di un infortunio da parte di 2
+il giocatore 6 scarta il giocatore 3
+il giocatore 6 scarta il giocatore 3
+il giocatore 3 prende la palla da 6
+il giocatore 3 scarta il giocatore 6
+il giocatore 3 scarta il giocatore 7
+il giocatore 3 tira... e ha mancato la porta...
+il giocatore 8 e' vittima di un infortunio da parte di 4
+il giocatore 6 scarta il giocatore 3
+il giocatore 6 scarta il giocatore 1
+il giocatore 6 scarta il giocatore 1
+il giocatore 0 prende la palla da 6
+il giocatore 0 scarta il giocatore 7
+il giocatore 6 prende la palla da 0
+il giocatore 3 prende la palla da 6
+il giocatore 3 scarta il giocatore 5
+il giocatore 3 tira... ed e' GOAL!!!
+il giocatore 5 scarta il giocatore 3
+il giocatore 0 prende la palla da 5
+il giocatore 9 prende la palla da 0
+il giocatore 9 scarta il giocatore 3
+il giocatore 9 scarta il giocatore 0
+il giocatore 9 tira... ed e' GOAL!!!
+il giocatore 4 scarta il giocatore 9
+il giocatore 4 tira... ed e' GOAL!!!
+il giocatore 0 prende la palla da 7
+il giocatore 0 scarta il giocatore 5
+il giocatore 5 prende la palla da 0
+il giocatore 5 scarta il giocatore 1
+il giocatore 5 tira... ed e' GOAL!!!
+il giocatore 1 scarta il giocatore 9
+il giocatore 1 scarta il giocatore 6
+il giocatore 1 tira... e ha mancato la porta...
+il giocatore 7 scarta il giocatore 4
+il giocatore 7 tira... ed e' GOAL!!!
+il giocatore 9 prende la palla da 4
+il giocatore 9 scarta il giocatore 1
+il giocatore 9 scarta il giocatore 0
+il giocatore 9 tira... e ha mancato la porta...
+il giocatore 8 prende la palla da 3
+il giocatore 8 scarta il giocatore 0
+il giocatore 8 tira... ed e' GOAL!!!
+il giocatore 6 prende la palla da 4
+il giocatore 6 scarta il giocatore 0
+il giocatore 6 scarta il giocatore 4
+il giocatore 6 scarta il giocatore 4
+il giocatore 6 tira... ed e' GOAL!!!
+il giocatore 3 scarta il giocatore 5
+il giocatore 3 tira... e ha mancato la porta...
+il giocatore 1 prende la palla da 6
+il giocatore 1 scarta il giocatore 6
+il giocatore 7 prende la palla da 1
+il giocatore 7 scarta il giocatore 2
+il giocatore 7 scarta il giocatore 3
+il giocatore 7 tira... e ha mancato la porta...
+il giocatore 9 prende la palla da 1
+il giocatore 9 scarta il giocatore 2
+il giocatore 1 prende la palla da 9
+il giocatore 5 prende la palla da 1
+il giocatore 0 prende la palla da 5
+il giocatore 0 scarta il giocatore 7
+il giocatore 6 prende la palla da 0
+il giocatore 6 scarta il giocatore 1
+il giocatore 6 scarta il giocatore 4
+il giocatore 6 tira... e ha mancato la porta...
+il giocatore 4 scarta il giocatore 7
+il giocatore 4 scarta il giocatore 8
+il giocatore 4 e' vittima di un infortunio da parte di 7
+il giocatore 1 e' vittima di un infortunio da parte di 8
+il giocatore 9 prende la palla da 0
+il giocatore 3 prende la palla da 9
+il giocatore 3 scarta il giocatore 5
+il giocatore 9 prende la palla da 3
+il giocatore 9 scarta il giocatore 3
+il giocatore 9 scarta il giocatore 0
+il giocatore 9 tira... ed e' GOAL!!!
+il giocatore 9 prende la palla da 0
+il giocatore 9 e' vittima di un infortunio da parte di 3
+il giocatore 6 scarta il giocatore 0
+il giocatore 0 prende la palla da 6
+il giocatore 0 scarta il giocatore 8
+il giocatore 0 tira... ed e' GOAL!!!
+il giocatore 3 prende la palla da 6
+il giocatore 3 e' vittima di un infortunio da parte di 6
+il giocatore 0 scarta il giocatore 8
+il giocatore 0 tira... ed e' GOAL!!!
+il giocatore 4 prende la palla da 5
+il giocatore 4 scarta il giocatore 9
+il giocatore 4 scarta il giocatore 8
+il giocatore 4 scarta il giocatore 7
+il giocatore 4 tira... ed e' GOAL!!!
+il giocatore 1 prende la palla da 6
+il giocatore 9 prende la palla da 1
+il giocatore 2 prende la palla da 9
+il giocatore 2 scarta il giocatore 6
+il giocatore 2 tira... ed e' GOAL!!!
+il giocatore 9 scarta il giocatore 1
+il giocatore 9 tira... e ha mancato la porta...
+il giocatore 3 scarta il giocatore 5
+il giocatore 7 prende la palla da 3
+il giocatore 7 e' vittima di un infortunio da parte di 4
+il giocatore 5 e' vittima di un infortunio da parte di 2
+il giocatore 8 scarta il giocatore 3
+il giocatore 8 tira... ed e' GOAL!!!
+il giocatore 9 prende la palla da 1
+il giocatore 0 prende la palla da 9
+il giocatore 0 scarta il giocatore 9
+il giocatore 0 scarta il giocatore 6
+il giocatore 0 tira... ed e' GOAL!!!
+il giocatore 6 scarta il giocatore 3
+il giocatore 6 scarta il giocatore 3
+il giocatore 6 scarta il giocatore 2
+il giocatore 6 tira... ed e' GOAL!!!
+il giocatore 3 scarta il giocatore 7
+il giocatore 7 prende la palla da 3
+il giocatore 0 prende la palla da 7
+il giocatore 0 scarta il giocatore 6
+il giocatore 0 tira... e ha mancato la porta...
+il giocatore 3 prende la palla da 6
+il giocatore 3 scarta il giocatore 7
+il giocatore 3 scarta il giocatore 9
+il giocatore 3 tira... ed e' GOAL!!!
+il giocatore 9 scarta il giocatore 3
+il giocatore 4 prende la palla da 9
+il giocatore 4 scarta il giocatore 8
+il giocatore 4 scarta il giocatore 8
+il giocatore 4 scarta il giocatore 5
+il giocatore 4 tira... e ha mancato la porta...
+il giocatore 1 prende la palla da 8
+il giocatore 1 scarta il giocatore 5
+il giocatore 1 tira... ed e' GOAL!!!
+il giocatore 7 scarta il giocatore 2
+il giocatore 7 tira... ed e' GOAL!!!
+il giocatore 4 scarta il giocatore 6
+il giocatore 4 tira... e ha mancato la porta...
+il giocatore 8 scarta il giocatore 3
+il giocatore 8 scarta il giocatore 3
+il giocatore 0 prende la palla da 8
+il giocatore 8 prende la palla da 0
+il giocatore 8 scarta il giocatore 4
+il giocatore 8 scarta il giocatore 3
+il giocatore 8 scarta il giocatore 0
+il giocatore 8 scarta il giocatore 3
+il giocatore 8 tira... ed e' GOAL!!!
+il giocatore 5 prende la palla da 2
+il giocatore 3 prende la palla da 5
+il giocatore 3 scarta il giocatore 7
+il giocatore 9 prende la palla da 3
+il giocatore 9 scarta il giocatore 2
+il giocatore 9 tira... e ha mancato la porta...
+il giocatore 6 prende la palla da 4
+il giocatore 0 prende la palla da 6
+il giocatore 0 scarta il giocatore 5
+il giocatore 0 tira... e ha mancato la porta...
+il giocatore 8 scarta il giocatore 3
+il giocatore 8 scarta il giocatore 1
+il giocatore 8 tira... ed e' GOAL!!!
+il giocatore 5 prende la palla da 0
+il giocatore 5 scarta il giocatore 1
+il giocatore 5 tira... e ha mancato la porta...
+il giocatore 6 prende la palla da 1
+il giocatore 2 prende la palla da 6
+il giocatore 2 scarta il giocatore 8
+il giocatore 5 prende la palla da 2
+il giocatore 0 prende la palla da 5
+il giocatore 0 scarta il giocatore 8
+il giocatore 0 scarta il giocatore 7
+il giocatore 0 e' vittima di un infortunio da parte di 5
+il giocatore 1 scarta il giocatore 6
+il giocatore 1 tira... e ha mancato la porta...
+il giocatore 9 scarta il giocatore 1
+il giocatore 9 tira... e ha mancato la porta...
+il giocatore 7 prende la palla da 2
+il giocatore 7 e' vittima di un infortunio da parte di 4
+il giocatore 1 prende la palla da 8
+il giocatore 1 scarta il giocatore 9
+il giocatore 1 scarta il giocatore 6
+il giocatore 1 scarta il giocatore 9
+il giocatore 1 tira... e ha mancato la porta...
+il giocatore 1 prende la palla da 9
+il giocatore 1 scarta il giocatore 6
+il giocatore 1 scarta il giocatore 8
+il giocatore 1 tira... ed e' GOAL!!!
+il giocatore 9 scarta il giocatore 2
+il giocatore 9 tira... e ha mancato la porta...
+il giocatore 2 scarta il giocatore 9
+il giocatore 2 e' vittima di un infortunio da parte di 9
+il giocatore 5 prende la palla da 0
+il giocatore 5 scarta il giocatore 1
+il giocatore 5 scarta il giocatore 3
+il giocatore 3 prende la palla da 5
+il giocatore 3 scarta il giocatore 7
+il giocatore 3 scarta il giocatore 6
+il giocatore 3 scarta il giocatore 6
+il giocatore 3 tira... e ha mancato la porta...
+il giocatore 4 prende la palla da 9
+il giocatore 4 scarta il giocatore 8
+il giocatore 4 scarta il giocatore 7
+il giocatore 4 scarta il giocatore 5
+il giocatore 4 tira... e ha mancato la porta...
+il giocatore 2 prende la palla da 7
+il giocatore 2 scarta il giocatore 6
+il giocatore 5 prende la palla da 2
+il giocatore 5 scarta il giocatore 3
+il giocatore 5 scarta il giocatore 1
+il giocatore 5 tira... e ha mancato la porta...
+il giocatore 3 scarta il giocatore 6
+il giocatore 3 tira... e ha mancato la porta...
+il giocatore 3 prende la palla da 5
+il giocatore 3 scarta il giocatore 9
+il giocatore 3 scarta il giocatore 5
+il giocatore 3 scarta il giocatore 8
+il giocatore 3 tira... ed e' GOAL!!!
+il giocatore 6 scarta il giocatore 2
+il giocatore 6 scarta il giocatore 1
+il giocatore 1 prende la palla da 6
+il giocatore 9 prende la palla da 1
+il giocatore 9 scarta il giocatore 4
+il giocatore 9 scarta il giocatore 0
+il giocatore 4 prende la palla da 9
+il giocatore 4 scarta il giocatore 7
+il giocatore 6 prende la palla da 4
+il giocatore 6 scarta il giocatore 3
+il giocatore 6 scarta il giocatore 1
+il giocatore 6 tira... ed e' GOAL!!!
+il giocatore 7 prende la palla da 1
+il giocatore 7 scarta il giocatore 1
+il giocatore 7 scarta il giocatore 3
+il giocatore 7 scarta il giocatore 2
+il giocatore 7 tira... ed e' GOAL!!!
+il giocatore 0 scarta il giocatore 6
+il giocatore 0 tira... ed e' GOAL!!!
+il giocatore 9 scarta il giocatore 2
+il giocatore 2 prende la palla da 9
+il giocatore 5 prende la palla da 2
+il giocatore 4 prende la palla da 5
+il giocatore 4 e' vittima di un infortunio da parte di 5
+il giocatore 8 prende la palla da 2
+il giocatore 1 prende la palla da 8
+il giocatore 1 scarta il giocatore 6
+il giocatore 1 tira... e ha mancato la porta...
+il giocatore 2 prende la palla da 6
+il giocatore 2 scarta il giocatore 5
+il giocatore 2 scarta il giocatore 7
+il giocatore 5 prende la palla da 2
+il giocatore 5 scarta il giocatore 0
+il giocatore 0 prende la palla da 5
+il giocatore 0 scarta il giocatore 6
+il giocatore 0 tira... ed e' GOAL!!!
+il giocatore 2 prende la palla da 9
+il giocatore 2 scarta il giocatore 5
+il giocatore 2 scarta il giocatore 9
+il giocatore 2 scarta il giocatore 8
+il giocatore 2 tira... ed e' GOAL!!!
+il giocatore 5 scarta il giocatore 0
+il giocatore 5 tira... e ha mancato la porta...
+il giocatore 6 prende la palla da 3
+il giocatore 6 scarta il giocatore 4
+il giocatore 6 scarta il giocatore 0
+il giocatore 6 tira... e ha mancato la porta...
+il giocatore 3 scarta il giocatore 8
+il giocatore 3 tira... e ha mancato la porta...
+il giocatore 6 scarta il giocatore 2
+il giocatore 0 prende la palla da 6
+il giocatore 0 scarta il giocatore 6
+il giocatore 6 prende la palla da 0
+il giocatore 6 scarta il giocatore 4
+il giocatore 6 tira... ed e' GOAL!!!
+il giocatore 2 scarta il giocatore 8
+il giocatore 2 tira... e ha mancato la porta...
+il giocatore 5 scarta il giocatore 0
+il giocatore 5 e' vittima di un infortunio da parte di 3
+il giocatore 9 scarta il giocatore 0
+il giocatore 9 tira... ed e' GOAL!!!
+il giocatore 1 e' vittima di un infortunio da parte di 6
+il giocatore 9 prende la palla da 0
+il giocatore 9 scarta il giocatore 2
+il giocatore 0 prende la palla da 9
+il giocatore 0 scarta il giocatore 8
+il giocatore 0 e' vittima di un infortunio da parte di 9
+il giocatore 3 scarta il giocatore 6
+il giocatore 3 scarta il giocatore 6
+il giocatore 3 tira... ed e' GOAL!!!
+il giocatore 4 prende la palla da 6
+il giocatore 4 e' vittima di un infortunio da parte di 5
+il giocatore 2 scarta il giocatore 8
+il giocatore 2 tira... ed e' GOAL!!!
+il giocatore 8 scarta il giocatore 2
+il giocatore 8 scarta il giocatore 3
+il giocatore 8 tira... ed e' GOAL!!!
+il giocatore 3 scarta il giocatore 6
+il giocatore 3 scarta il giocatore 6
+il giocatore 3 scarta il giocatore 9
+il giocatore 3 tira... e ha mancato la porta...
+il giocatore 7 scarta il giocatore 3
+il giocatore 7 tira... e ha mancato la porta...
+il giocatore 3 scarta il giocatore 6
+il giocatore 6 prende la palla da 3
+il giocatore 3 prende la palla da 6
+il giocatore 3 scarta il giocatore 6
+il giocatore 8 prende la palla da 3
+il giocatore 8 scarta il giocatore 3
+il giocatore 8 scarta il giocatore 3
+il giocatore 8 tira... e ha mancato la porta...
+il giocatore 7 prende la palla da 1
+il giocatore 7 scarta il giocatore 2
+il giocatore 7 tira... ed e' GOAL!!!
+il giocatore 4 scarta il giocatore 9
+il giocatore 4 scarta il giocatore 8
+il giocatore 4 tira... ed e' GOAL!!!
+il giocatore 9 scarta il giocatore 4
+il giocatore 9 tira... ed e' GOAL!!!
+il giocatore 2 scarta il giocatore 6
+il giocatore 2 scarta il giocatore 7
+il giocatore 2 tira... ed e' GOAL!!!
+il giocatore 9 scarta il giocatore 4
+il giocatore 0 prende la palla da 9
+il giocatore 0 scarta il giocatore 9
+il giocatore 0 scarta il giocatore 8
+il giocatore 0 tira... ed e' GOAL!!!
+il giocatore 9 scarta il giocatore 3
+il giocatore 2 prende la palla da 9
+il giocatore 2 scarta il giocatore 5
+il giocatore 2 scarta il giocatore 6
+il giocatore 2 tira... ed e' GOAL!!!
+il giocatore 9 scarta il giocatore 2
+il giocatore 9 tira... ed e' GOAL!!!
+il giocatore 8 prende la palla da 3
+il giocatore 8 scarta il giocatore 4
+il giocatore 8 scarta il giocatore 2
+il giocatore 8 tira... e ha mancato la porta...
+il giocatore 0 e' vittima di un infortunio da parte di 6
+il giocatore 2 scarta il giocatore 5
+il giocatore 2 scarta il giocatore 7
+il giocatore 2 tira... e ha mancato la porta...
+il giocatore 5 scarta il giocatore 1
+il giocatore 5 e' vittima di un infortunio da parte di 4
+il giocatore 3 prende la palla da 8
+il giocatore 6 prende la palla da 3
+il giocatore 6 scarta il giocatore 1
+il giocatore 3 prende la palla da 6
+il giocatore 3 scarta il giocatore 7
+il giocatore 7 prende la palla da 3
+il giocatore 2 prende la palla da 7
+il giocatore 2 scarta il giocatore 7
+il giocatore 2 tira... e ha mancato la porta...
+il giocatore 8 scarta il giocatore 1
+il giocatore 8 tira... ed e' GOAL!!!
+il giocatore 9 prende la palla da 4
+il giocatore 9 scarta il giocatore 2
+il giocatore 9 tira... e ha mancato la porta...
+il giocatore 6 prende la palla da 4
+il giocatore 4 prende la palla da 6
+il giocatore 4 scarta il giocatore 9
+il giocatore 4 scarta il giocatore 9
+il giocatore 4 scarta il giocatore 9
+il giocatore 4 scarta il giocatore 9
+il giocatore 4 tira... e ha mancato la porta...
+il giocatore 9 scarta il giocatore 2
+il giocatore 9 tira... ed e' GOAL!!!
+il giocatore 0 scarta il giocatore 6
+il giocatore 0 scarta il giocatore 9
+il giocatore 0 scarta il giocatore 9
+il giocatore 0 tira... e ha mancato la porta...
+il giocatore 5 scarta il giocatore 4
+il giocatore 1 prende la palla da 5
+il giocatore 7 prende la palla da 1
+il giocatore 7 scarta il giocatore 3
+il giocatore 7 e' vittima di un infortunio da parte di 1
+il giocatore 6 scarta il giocatore 3
+il giocatore 6 tira... e ha mancato la porta...
+il giocatore 5 prende la palla da 4
+il giocatore 5 scarta il giocatore 3
+il giocatore 3 prende la palla da 5
+il giocatore 3 scarta il giocatore 5
+il giocatore 3 tira... ed e' GOAL!!!
+il giocatore 9 e' vittima di un infortunio da parte di 3
+il giocatore 0 prende la palla da 6
+il giocatore 6 prende la palla da 0
+il giocatore 0 prende la palla da 6
+il giocatore 0 scarta il giocatore 8
+il giocatore 0 tira... e ha mancato la porta...
+il giocatore 2 prende la palla da 5
+il giocatore 2 scarta il giocatore 5
+il giocatore 6 prende la palla da 2
+il giocatore 3 prende la palla da 6
+il giocatore 3 scarta il giocatore 8
+il giocatore 8 prende la palla da 3
+il giocatore 2 prende la palla da 8
+il giocatore 2 scarta il giocatore 6
+il giocatore 5 prende la palla da 2
+il giocatore 0 prende la palla da 5
+il giocatore 0 scarta il giocatore 7
+il giocatore 5 prende la palla da 0
+il giocatore 5 scarta il giocatore 4
+il giocatore 5 scarta il giocatore 3
+il giocatore 5 tira... ed e' GOAL!!!
+il giocatore 4 scarta il giocatore 7
+il giocatore 4 scarta il giocatore 9
+il giocatore 4 tira... e ha mancato la porta...
+il giocatore 5 scarta il giocatore 2
+il giocatore 5 scarta il giocatore 1
+il giocatore 5 tira... e ha mancato la porta...
+il giocatore 6 prende la palla da 0
+il giocatore 6 scarta il giocatore 3
+il giocatore 6 scarta il giocatore 1
+il giocatore 6 tira... e ha mancato la porta...
+il giocatore 0 scarta il giocatore 7
+il giocatore 0 scarta il giocatore 8
+il giocatore 0 tira... ed e' GOAL!!!
+il giocatore 6 e' vittima di un infortunio da parte di 2
+il giocatore 9 scarta il giocatore 0
+il giocatore 4 prende la palla da 9
+il giocatore 4 scarta il giocatore 5
+il giocatore 4 scarta il giocatore 7
+il giocatore 4 tira... ed e' GOAL!!!
+il giocatore 5 scarta il giocatore 4
+il giocatore 5 scarta il giocatore 1
+il giocatore 5 tira... ed e' GOAL!!!
+il giocatore 0 scarta il giocatore 5
+il giocatore 0 tira... ed e' GOAL!!!
+il giocatore 8 scarta il giocatore 2
+il giocatore 8 scarta il giocatore 0
+il giocatore 8 tira... e ha mancato la porta...
+il giocatore 4 scarta il giocatore 5
+il giocatore 4 scarta il giocatore 6
+il giocatore 4 tira... e ha mancato la porta...
+il giocatore 5 scarta il giocatore 4
+il giocatore 5 scarta il giocatore 4
+il giocatore 5 tira... e ha mancato la porta...
+il giocatore 0 scarta il giocatore 7
+il giocatore 5 prende la palla da 0
+il giocatore 5 scarta il giocatore 4
+il giocatore 5 scarta il giocatore 2
+il giocatore 5 scarta il giocatore 1
+il giocatore 5 tira... e ha mancato la porta...
+il giocatore 1 scarta il giocatore 7
+il giocatore 1 scarta il giocatore 8
+il giocatore 1 tira... ed e' GOAL!!!
+il giocatore 7 scarta il giocatore 0
+il giocatore 7 tira... e ha mancato la porta...
+il giocatore 2 scarta il giocatore 5
+il giocatore 2 scarta il giocatore 6
+il giocatore 2 tira... ed e' GOAL!!!
+il giocatore 9 scarta il giocatore 3
+il giocatore 9 tira... e ha mancato la porta...
+il giocatore 9 prende la palla da 3
+il giocatore 9 scarta il giocatore 4
+il giocatore 3 prende la palla da 9
+il giocatore 3 e' vittima di un infortunio da parte di 5
+il giocatore 4 scarta il giocatore 7
+il giocatore 9 prende la palla da 4
+il giocatore 9 scarta il giocatore 0
+il giocatore 9 scarta il giocatore 4
+il giocatore 9 tira... ed e' GOAL!!!
+il giocatore 0 scarta il giocatore 6
+il giocatore 0 tira... e ha mancato la porta...
+il giocatore 8 scarta il giocatore 4
+il giocatore 8 scarta il giocatore 1
+il giocatore 8 tira... ed e' GOAL!!!
+il giocatore 5 prende la palla da 0
+il giocatore 5 scarta il giocatore 4
+il giocatore 5 scarta il giocatore 0
+il giocatore 5 tira... e ha mancato la porta...
+il giocatore 0 scarta il giocatore 8
+il giocatore 0 scarta il giocatore 9
+il giocatore 0 tira... ed e' GOAL!!!
+il giocatore 1 prende la palla da 6
+il giocatore 1 scarta il giocatore 7
+il giocatore 1 scarta il giocatore 6
+il giocatore 1 tira... ed e' GOAL!!!
+il giocatore 2 prende la palla da 7
+il giocatore 2 scarta il giocatore 8
+il giocatore 2 scarta il giocatore 9
+il giocatore 2 scarta il giocatore 8
+il giocatore 2 tira... ed e' GOAL!!!
+il giocatore 7 scarta il giocatore 3
+il giocatore 7 tira... e ha mancato la porta...
+il giocatore 8 prende la palla da 0
+il giocatore 8 scarta il giocatore 3
+il giocatore 8 scarta il giocatore 1
+il giocatore 8 tira... ed e' GOAL!!!
+il giocatore 1 scarta il giocatore 8
+il giocatore 1 scarta il giocatore 9
+il giocatore 1 scarta il giocatore 6
+il giocatore 1 tira... e ha mancato la porta...
+il giocatore 7 scarta il giocatore 2
+il giocatore 7 tira... ed e' GOAL!!!
+il giocatore 4 scarta il giocatore 7
+il giocatore 4 tira... e ha mancato la porta...
+il giocatore 9 scarta il giocatore 1
+il giocatore 9 tira... ed e' GOAL!!!
+il giocatore 3 scarta il giocatore 8
+il giocatore 3 tira... ed e' GOAL!!!
+il giocatore 2 prende la palla da 6
+il giocatore 2 scarta il giocatore 9
+il giocatore 2 tira... ed e' GOAL!!!
+il giocatore 7 e' vittima di un infortunio da parte di 2
+il giocatore 4 prende la palla da 8
+il giocatore 6 prende la palla da 4
+il giocatore 6 scarta il giocatore 3
+il giocatore 6 scarta il giocatore 3
+il giocatore 6 scarta il giocatore 0
+il giocatore 6 tira... e ha mancato la porta...
+il giocatore 3 scarta il giocatore 6
+il giocatore 3 scarta il giocatore 9
+il giocatore 3 scarta il giocatore 9
+il giocatore 3 tira... ed e' GOAL!!!
+il giocatore 9 scarta il giocatore 0
+il giocatore 1 prende la palla da 9
+il giocatore 1 e' vittima di un infortunio da parte di 9
+il giocatore 8 prende la palla da 4
+il giocatore 8 scarta il giocatore 0
+il giocatore 8 scarta il giocatore 3
+il giocatore 8 e' vittima di un infortunio da parte di 4
+il giocatore 5 scarta il giocatore 0
+il giocatore 5 e' vittima di un infortunio da parte di 3
+il giocatore 0 prende la palla da 9
+il giocatore 6 prende la palla da 0
+il giocatore 6 scarta il giocatore 2
+il giocatore 2 prende la palla da 6
+il giocatore 6 prende la palla da 2
+il giocatore 6 scarta il giocatore 2
+il giocatore 6 e' vittima di un infortunio da parte di 2
+il giocatore 3 prende la palla da 7
+il giocatore 3 scarta il giocatore 9
+il giocatore 7 prende la palla da 3
+il giocatore 7 scarta il giocatore 0
+il giocatore 7 scarta il giocatore 2
+il giocatore 7 tira... ed e' GOAL!!!
+il giocatore 1 scarta il giocatore 8
+il giocatore 1 e' vittima di un infortunio da parte di 9
+il giocatore 5 prende la palla da 4
+il giocatore 5 scarta il giocatore 3
+il giocatore 5 scarta il giocatore 2
+il giocatore 5 tira... e ha mancato la porta...
+il giocatore 4 scarta il giocatore 7
+il giocatore 4 tira... ed e' GOAL!!!
+il giocatore 6 scarta il giocatore 4
+il giocatore 6 tira... e ha mancato la porta...
+il giocatore 0 scarta il giocatore 6
+il giocatore 0 scarta il giocatore 8
+il giocatore 9 prende la palla da 0
+il giocatore 9 scarta il giocatore 4
+il giocatore 9 scarta il giocatore 2
+il giocatore 9 tira... e ha mancato la porta...
+il giocatore 4 scarta il giocatore 6
+il giocatore 4 scarta il giocatore 5
+il giocatore 4 tira... ed e' GOAL!!!
+il giocatore 4 prende la palla da 9
+il giocatore 4 scarta il giocatore 9
+il giocatore 4 scarta il giocatore 5
+il giocatore 4 tira... ed e' GOAL!!!
+il giocatore 2 prende la palla da 5
+il giocatore 2 e' vittima di un infortunio da parte di 8
+il giocatore 0 scarta il giocatore 5
+il giocatore 0 scarta il giocatore 7
+il giocatore 0 tira... ed e' GOAL!!!
+il giocatore 6 scarta il giocatore 1
+il giocatore 3 prende la palla da 6
+il giocatore 3 scarta il giocatore 9
+il giocatore 3 tira... e ha mancato la porta...
+il giocatore 9 scarta il giocatore 4
+il giocatore 9 scarta il giocatore 0
+il giocatore 9 tira... ed e' GOAL!!!
+il giocatore 6 prende la palla da 3
+il giocatore 6 scarta il giocatore 1
+il giocatore 6 scarta il giocatore 0
+il giocatore 4 prende la palla da 6
+il giocatore 4 scarta il giocatore 9
+il giocatore 4 tira... ed e' GOAL!!!
+il giocatore 1 prende la palla da 9
+il giocatore 1 scarta il giocatore 9
+il giocatore 1 tira... e ha mancato la porta...
+il giocatore 4 prende la palla da 8
+il giocatore 4 scarta il giocatore 6
+il giocatore 4 scarta il giocatore 9
+il giocatore 4 tira... e ha mancato la porta...
+il giocatore 9 scarta il giocatore 3
+il giocatore 3 prende la palla da 9
+il giocatore 3 scarta il giocatore 7
+il giocatore 3 tira... e ha mancato la porta...
+il giocatore 8 scarta il giocatore 2
+il giocatore 8 scarta il giocatore 1
+il giocatore 8 scarta il giocatore 3
+il giocatore 8 tira... ed e' GOAL!!!
+il giocatore 2 scarta il giocatore 7
+il giocatore 6 prende la palla da 2
+il giocatore 0 prende la palla da 6
+il giocatore 9 prende la palla da 0
+il giocatore 9 e' vittima di un infortunio da parte di 4
+il giocatore 6 e' vittima di un infortunio da parte di 3
+il giocatore 7 scarta il giocatore 2
+il giocatore 0 prende la palla da 7
+il giocatore 0 scarta il giocatore 7
+il giocatore 0 tira... e ha mancato la porta...
+il giocatore 2 prende la palla da 7
+il giocatore 2 scarta il giocatore 5
+il giocatore 8 prende la palla da 2
+il giocatore 8 e' vittima di un infortunio da parte di 0
+il giocatore 1 prende la palla da 9
+il giocatore 1 scarta il giocatore 9
+il giocatore 9 prende la palla da 1
+il giocatore 9 scarta il giocatore 1
+il giocatore 9 e' vittima di un infortunio da parte di 3
+il giocatore 7 scarta il giocatore 4
+il giocatore 7 scarta il giocatore 0
+il giocatore 7 tira... e ha mancato la porta...
+il giocatore 5 prende la palla da 1
+il giocatore 5 scarta il giocatore 4
+il giocatore 5 scarta il giocatore 2
+il giocatore 5 tira... ed e' GOAL!!!
+il giocatore 1 scarta il giocatore 6
+il giocatore 1 scarta il giocatore 7
+il giocatore 1 tira... ed e' GOAL!!!
+il giocatore 5 scarta il giocatore 2
+il giocatore 1 prende la palla da 5
+il giocatore 1 scarta il giocatore 5
+il giocatore 7 prende la palla da 1
+il giocatore 0 prende la palla da 7
+il giocatore 0 scarta il giocatore 9
+il giocatore 0 scarta il giocatore 8
+il giocatore 8 prende la palla da 0
+il giocatore 8 scarta il giocatore 1
+il giocatore 1 prende la palla da 8
+il giocatore 1 scarta il giocatore 9
+il giocatore 1 tira... ed e' GOAL!!!
+il giocatore 4 prende la palla da 8
+il giocatore 4 scarta il giocatore 8
+il giocatore 9 prende la palla da 4
+il giocatore 9 scarta il giocatore 4
+il giocatore 9 scarta il giocatore 3
+il giocatore 9 e' vittima di un infortunio da parte di 2
+il giocatore 8 scarta il giocatore 0
+il giocatore 8 scarta il giocatore 4
+il giocatore 8 tira... ed e' GOAL!!!
+il giocatore 6 prende la palla da 0
+il giocatore 0 prende la palla da 6
+il giocatore 0 scarta il giocatore 6
+il giocatore 0 scarta il giocatore 5
+il giocatore 0 tira... e ha mancato la porta...
+il giocatore 0 prende la palla da 5
+il giocatore 5 prende la palla da 0
+il giocatore 5 scarta il giocatore 4
+il giocatore 5 scarta il giocatore 3
+il giocatore 3 prende la palla da 5
+il giocatore 3 scarta il giocatore 6
+il giocatore 5 prende la palla da 3
+il giocatore 2 prende la palla da 5
+il giocatore 7 prende la palla da 2
+il giocatore 0 prende la palla da 7
+il giocatore 0 scarta il giocatore 5
+il giocatore 0 tira... e ha mancato la porta...
+il giocatore 8 scarta il giocatore 0
+il giocatore 3 prende la palla da 8
+il giocatore 3 scarta il giocatore 7
+il giocatore 8 prende la palla da 3
+il giocatore 8 scarta il giocatore 0
+il giocatore 8 tira... e ha mancato la porta...
+il giocatore 8 prende la palla da 2
+il giocatore 3 prende la palla da 8
+il giocatore 3 scarta il giocatore 8
+il giocatore 3 scarta il giocatore 7
+il giocatore 3 scarta il giocatore 5
+il giocatore 3 tira... ed e' GOAL!!!
+il giocatore 9 scarta il giocatore 0
+il giocatore 9 scarta il giocatore 3
+il giocatore 2 prende la palla da 9
+il giocatore 2 scarta il giocatore 9
+il giocatore 2 tira... e ha mancato la porta...
+il giocatore 5 scarta il giocatore 2
+il giocatore 4 prende la palla da 5
+il giocatore 4 scarta il giocatore 9
+il giocatore 4 tira... e ha mancato la porta...
+il giocatore 6 scarta il giocatore 0
+il giocatore 0 prende la palla da 6
+il giocatore 0 scarta il giocatore 9
+il giocatore 0 scarta il giocatore 5
+il giocatore 7 prende la palla da 0
+il giocatore 7 scarta il giocatore 2
+il giocatore 3 prende la palla da 7
+il giocatore 3 scarta il giocatore 7
+il giocatore 6 prende la palla da 3
+il giocatore 6 scarta il giocatore 1
+il giocatore 6 scarta il giocatore 3
+il giocatore 3 prende la palla da 6
+il giocatore 3 scarta il giocatore 5
+il giocatore 3 tira... ed e' GOAL!!!
+il giocatore 9 scarta il giocatore 3
+il giocatore 9 scarta il giocatore 0
+il giocatore 9 tira... ed e' GOAL!!!
+il giocatore 1 e' vittima di un infortunio da parte di 8
+il giocatore 6 prende la palla da 3
+il giocatore 6 scarta il giocatore 3
+il giocatore 2 prende la palla da 6
+il giocatore 2 scarta il giocatore 7
+il giocatore 5 prende la palla da 2
+il giocatore 5 e' vittima di un infortunio da parte di 0
+il giocatore 9 scarta il giocatore 2
+il giocatore 9 scarta il giocatore 2
+il giocatore 9 tira... e ha mancato la porta...
+il giocatore 7 prende la palla da 3
+il giocatore 3 prende la palla da 7
+il giocatore 6 prende la palla da 3
+il giocatore 0 prende la palla da 6
+il giocatore 8 prende la palla da 0
+il giocatore 4 prende la palla da 8
+il giocatore 8 prende la palla da 4
+il giocatore 8 scarta il giocatore 1
+il giocatore 8 scarta il giocatore 4
+il giocatore 0 prende la palla da 8
+il giocatore 0 e' vittima di un infortunio da parte di 9
+il giocatore 5 prende la palla da 4
+il giocatore 5 scarta il giocatore 3
+il giocatore 2 prende la palla da 5
+il giocatore 2 scarta il giocatore 5
+il giocatore 2 tira... ed e' GOAL!!!
+il giocatore 2 prende la palla da 8
+il giocatore 8 prende la palla da 2
+il giocatore 3 prende la palla da 8
+il giocatore 5 prende la palla da 3
+il giocatore 5 scarta il giocatore 4
+il giocatore 5 tira... e ha mancato la porta...
+il giocatore 9 prende la palla da 4
+il giocatore 9 scarta il giocatore 4
+il giocatore 9 tira... ed e' GOAL!!!
+il giocatore 2 scarta il giocatore 6
+il giocatore 8 prende la palla da 2
+il giocatore 2 prende la palla da 8
+il giocatore 2 scarta il giocatore 6
+il giocatore 2 scarta il giocatore 5
+il giocatore 2 tira... e ha mancato la porta...
+il giocatore 3 prende la palla da 6
+il giocatore 5 prende la palla da 3
+il giocatore 5 scarta il giocatore 2
+il giocatore 5 scarta il giocatore 3
+il giocatore 5 e' vittima di un infortunio da parte di 2
+il giocatore 8 scarta il giocatore 0
+il giocatore 0 prende la palla da 8
+il giocatore 9 prende la palla da 0
+il giocatore 9 scarta il giocatore 3
+il giocatore 9 e' vittima di un infortunio da parte di 2
+il giocatore 6 scarta il giocatore 4
+il giocatore 6 scarta il giocatore 1
+il giocatore 6 scarta il giocatore 1
+il giocatore 6 tira... e ha mancato la porta...
+il giocatore 4 scarta il giocatore 8
+il giocatore 4 tira... e ha mancato la porta...
+il giocatore 1 prende la palla da 5
+il giocatore 1 scarta il giocatore 6
+il giocatore 1 tira... ed e' GOAL!!!
+il giocatore 6 scarta il giocatore 2
+il giocatore 2 prende la palla da 6
+il giocatore 2 scarta il giocatore 7
+il giocatore 2 scarta il giocatore 7
+il giocatore 2 tira... ed e' GOAL!!!
+il giocatore 4 prende la palla da 5
+il giocatore 4 scarta il giocatore 5
+il giocatore 4 tira... e ha mancato la porta...
+il giocatore 8 scarta il giocatore 1
+il giocatore 8 tira... ed e' GOAL!!!
+il giocatore 4 scarta il giocatore 9
+il giocatore 8 prende la palla da 4
+il giocatore 0 prende la palla da 8
+il giocatore 9 prende la palla da 0
+il giocatore 9 scarta il giocatore 4
+il giocatore 1 prende la palla da 9
+il giocatore 5 prende la palla da 1
+il giocatore 1 prende la palla da 5
+il giocatore 1 scarta il giocatore 7
+il giocatore 9 prende la palla da 1
+il giocatore 9 scarta il giocatore 1
+il giocatore 9 tira... e ha mancato la porta...
+il giocatore 0 scarta il giocatore 7
+il giocatore 0 scarta il giocatore 8
+il giocatore 0 scarta il giocatore 6
+il giocatore 0 tira... ed e' GOAL!!!
+il giocatore 1 prende la palla da 5
+il giocatore 7 prende la palla da 1
+il giocatore 7 scarta il giocatore 4
+il giocatore 0 prende la palla da 7
+il giocatore 0 scarta il giocatore 8
+il giocatore 0 scarta il giocatore 8
+il giocatore 0 tira... ed e' GOAL!!!
+il giocatore 3 prende la palla da 5
+il giocatore 3 scarta il giocatore 6
+il giocatore 5 prende la palla da 3
+il giocatore 5 scarta il giocatore 1
+il giocatore 5 tira... ed e' GOAL!!!
+il giocatore 9 prende la palla da 1
+il giocatore 9 scarta il giocatore 4
+il giocatore 9 tira... e ha mancato la porta...
+il giocatore 5 prende la palla da 1
+il giocatore 5 scarta il giocatore 3
+il giocatore 5 tira... e ha mancato la porta...
+il giocatore 8 prende la palla da 0
+il giocatore 8 scarta il giocatore 2
+il giocatore 3 prende la palla da 8
+il giocatore 3 scarta il giocatore 7
+il giocatore 3 scarta il giocatore 5
+il giocatore 3 tira... ed e' GOAL!!!
+il giocatore 9 scarta il giocatore 3
+il giocatore 9 scarta il giocatore 4
+il giocatore 9 scarta il giocatore 0
+il giocatore 9 tira... ed e' GOAL!!!
+il giocatore 3 scarta il giocatore 5
+il giocatore 7 prende la palla da 3
+il giocatore 1 prende la palla da 7
+il giocatore 6 prende la palla da 1
+il giocatore 6 scarta il giocatore 3
+il giocatore 6 tira... ed e' GOAL!!!
+il giocatore 6 prende la palla da 1
+il giocatore 6 scarta il giocatore 1
+il giocatore 6 scarta il giocatore 1
+il giocatore 6 tira... e ha mancato la porta...
+il giocatore 9 prende la palla da 4
+il giocatore 9 scarta il giocatore 3
+il giocatore 9 tira... e ha mancato la porta...
+il giocatore 2 scarta il giocatore 7
+il giocatore 2 scarta il giocatore 5
+il giocatore 2 tira... ed e' GOAL!!!
+il giocatore 9 scarta il giocatore 4
+il giocatore 1 prende la palla da 9
+il giocatore 6 prende la palla da 1
+il giocatore 6 scarta il giocatore 2
+il giocatore 6 scarta il giocatore 3
+il giocatore 6 tira... ed e' GOAL!!!
+il giocatore 2 scarta il giocatore 5
+il giocatore 2 scarta il giocatore 7
+il giocatore 2 tira... e ha mancato la porta...
+il giocatore 3 prende la palla da 8
+il giocatore 3 scarta il giocatore 7
+il giocatore 7 prende la palla da 3
+il giocatore 3 prende la palla da 7
+il giocatore 3 e' vittima di un infortunio da parte di 5
+il giocatore 1 scarta il giocatore 6
+il giocatore 1 tira... e ha mancato la porta...
+il giocatore 4 prende la palla da 6
+il giocatore 4 scarta il giocatore 9
+il giocatore 4 tira... e ha mancato la porta...
+il giocatore 7 scarta il giocatore 2
+il giocatore 7 scarta il giocatore 1
+il giocatore 7 tira... ed e' GOAL!!!
+il giocatore 0 scarta il giocatore 8
+il giocatore 0 scarta il giocatore 8
+il giocatore 0 tira... e ha mancato la porta...
+il giocatore 6 scarta il giocatore 2
+il giocatore 6 tira... e ha mancato la porta...
+il giocatore 4 scarta il giocatore 9
+il giocatore 4 e' vittima di un infortunio da parte di 8
+il giocatore 2 scarta il giocatore 9
+il giocatore 2 scarta il giocatore 5
+il giocatore 2 tira... e ha mancato la porta...
+il giocatore 5 scarta il giocatore 1
+il giocatore 5 scarta il giocatore 3
+il giocatore 5 e' vittima di un infortunio da parte di 0
+il giocatore 2 prende la palla da 6
+il giocatore 2 scarta il giocatore 6
+il giocatore 2 tira... ed e' GOAL!!!
+il giocatore 7 scarta il giocatore 1
+il giocatore 7 scarta il giocatore 2
+il giocatore 7 tira... e ha mancato la porta...
+il giocatore 1 scarta il giocatore 9
+il giocatore 1 tira... e ha mancato la porta...
+il giocatore 7 scarta il giocatore 2
+il giocatore 7 scarta il giocatore 4
+il giocatore 1 prende la palla da 7
+il giocatore 1 scarta il giocatore 9
+il giocatore 1 scarta il giocatore 9
+il giocatore 1 tira... ed e' GOAL!!!
+il giocatore 8 e' vittima di un infortunio da parte di 3
+il giocatore 1 prende la palla da 7
+il giocatore 1 scarta il giocatore 6
+il giocatore 9 prende la palla da 1
+il giocatore 9 scarta il giocatore 1
+il giocatore 9 scarta il giocatore 1
+il giocatore 9 tira... ed e' GOAL!!!
+il giocatore 6 prende la palla da 0
+il giocatore 6 scarta il giocatore 4
+il giocatore 6 scarta il giocatore 1
+il giocatore 6 tira... e ha mancato la porta...
+il giocatore 7 prende la palla da 0
+il giocatore 7 scarta il giocatore 1
+il giocatore 7 scarta il giocatore 0
+il giocatore 1 prende la palla da 7
+il giocatore 9 prende la palla da 1
+il giocatore 4 prende la palla da 9
+il giocatore 4 scarta il giocatore 9
+il giocatore 7 prende la palla da 4
+il giocatore 7 scarta il giocatore 3
+il giocatore 7 scarta il giocatore 0
+il giocatore 7 scarta il giocatore 1
+il giocatore 7 tira... e ha mancato la porta...
+il giocatore 1 scarta il giocatore 6
+il giocatore 1 tira... ed e' GOAL!!!
+il giocatore 4 prende la palla da 7
+il giocatore 4 scarta il giocatore 7
+il giocatore 4 scarta il giocatore 6
+il giocatore 4 tira... ed e' GOAL!!!
+il giocatore 6 scarta il giocatore 2
+il giocatore 4 prende la palla da 6
+il giocatore 4 scarta il giocatore 6
+il giocatore 4 scarta il giocatore 8
+il giocatore 4 tira... e ha mancato la porta...
+il giocatore 2 prende la palla da 6
+il giocatore 6 prende la palla da 2
+il giocatore 6 scarta il giocatore 0
+il giocatore 6 tira... e ha mancato la porta...
+il giocatore 7 prende la palla da 3
+il giocatore 7 scarta il giocatore 3
+il giocatore 7 tira... e ha mancato la porta...
+il giocatore 6 prende la palla da 4
+il giocatore 6 scarta il giocatore 0
+il giocatore 6 scarta il giocatore 4
+il giocatore 6 tira... ed e' GOAL!!!
+il giocatore 4 e' vittima di un infortunio da parte di 8
+il giocatore 2 scarta il giocatore 5
+il giocatore 2 scarta il giocatore 9
+il giocatore 7 prende la palla da 2
+il giocatore 7 scarta il giocatore 2
+il giocatore 7 scarta il giocatore 0
+il giocatore 7 e' vittima di un infortunio da parte di 3
+il giocatore 8 scarta il giocatore 2
+il giocatore 0 prende la palla da 8
+il giocatore 0 scarta il giocatore 5
+il giocatore 0 tira... ed e' GOAL!!!
+il giocatore 6 scarta il giocatore 0
+il giocatore 6 scarta il giocatore 4
+il giocatore 6 tira... e ha mancato la porta...
+il giocatore 6 prende la palla da 0
+il giocatore 6 scarta il giocatore 1
+il giocatore 6 tira... e ha mancato la porta...
+il giocatore 0 scarta il giocatore 6
+il giocatore 0 scarta il giocatore 5
+il giocatore 0 tira... ed e' GOAL!!!
+il giocatore 2 prende la palla da 5
+il giocatore 2 scarta il giocatore 6
+il giocatore 8 prende la palla da 2
+il giocatore 1 prende la palla da 8
+il giocatore 6 prende la palla da 1
+il giocatore 6 scarta il giocatore 0
+il giocatore 6 scarta il giocatore 2
+il giocatore 4 prende la palla da 6
+il giocatore 8 prende la palla da 4
+il giocatore 8 scarta il giocatore 2
+il giocatore 8 scarta il giocatore 2
+il giocatore 8 tira... ed e' GOAL!!!
+il giocatore 4 scarta il giocatore 5
+il giocatore 8 prende la palla da 4
+il giocatore 4 prende la palla da 8
+il giocatore 4 scarta il giocatore 6
+il giocatore 4 scarta il giocatore 7
+il giocatore 4 tira... ed e' GOAL!!!
+il giocatore 2 prende la palla da 5
+il giocatore 2 scarta il giocatore 9
+il giocatore 2 tira... e ha mancato la porta...
+il giocatore 1 prende la palla da 9
+il giocatore 1 scarta il giocatore 7
+il giocatore 1 e' vittima di un infortunio da parte di 5
+il giocatore 8 prende la palla da 3
+il giocatore 4 prende la palla da 8
+il giocatore 6 prende la palla da 4
+il giocatore 3 prende la palla da 6
+il giocatore 3 scarta il giocatore 8
+il giocatore 3 tira... e ha mancato la porta...
+il giocatore 7 scarta il giocatore 2
+il giocatore 7 scarta il giocatore 2
+il giocatore 7 tira... ed e' GOAL!!!
+il giocatore 7 prende la palla da 2
+il giocatore 7 scarta il giocatore 2
+il giocatore 7 tira... e ha mancato la porta...
+il giocatore 7 prende la palla da 3
+il giocatore 7 scarta il giocatore 2
+il giocatore 7 tira... e ha mancato la porta...
+il giocatore 6 prende la palla da 2
+il giocatore 6 scarta il giocatore 3
+il giocatore 6 scarta il giocatore 1
+il giocatore 6 scarta il giocatore 3
+il giocatore 6 tira... e ha mancato la porta...
+il giocatore 4 scarta il giocatore 5
+il giocatore 7 prende la palla da 4
+il giocatore 4 prende la palla da 7
+il giocatore 9 prende la palla da 4
+il giocatore 2 prende la palla da 9
+il giocatore 2 scarta il giocatore 8
+il giocatore 2 scarta il giocatore 7
+il giocatore 2 tira... ed e' GOAL!!!
+il giocatore 4 prende la palla da 5
+il giocatore 4 scarta il giocatore 5
+il giocatore 8 prende la palla da 4
+il giocatore 8 e' vittima di un infortunio da parte di 1
+il giocatore 3 prende la palla da 6
+il giocatore 3 scarta il giocatore 7
+il giocatore 3 scarta il giocatore 6
+il giocatore 3 tira... ed e' GOAL!!!
+il giocatore 5 scarta il giocatore 4
+il giocatore 0 prende la palla da 5
+il giocatore 0 scarta il giocatore 6
+il giocatore 0 tira... e ha mancato la porta...
+il giocatore 3 prende la palla da 6
+il giocatore 3 e' vittima di un infortunio da parte di 9
+il giocatore 0 scarta il giocatore 5
+il giocatore 0 tira... e ha mancato la porta...
+il giocatore 7 scarta il giocatore 1
+il giocatore 7 scarta il giocatore 4
+il giocatore 7 tira... e ha mancato la porta...
+il giocatore 4 scarta il giocatore 8
+il giocatore 4 tira... e ha mancato la porta...
+il giocatore 4 prende la palla da 5
+il giocatore 4 scarta il giocatore 7
+il giocatore 7 prende la palla da 4
+il giocatore 7 scarta il giocatore 1
+il giocatore 0 prende la palla da 7
+il giocatore 7 prende la palla da 0
+il giocatore 7 scarta il giocatore 0
+il giocatore 7 scarta il giocatore 0
+il giocatore 7 scarta il giocatore 2
+il giocatore 7 tira... ed e' GOAL!!!
+il giocatore 9 prende la palla da 4
+il giocatore 0 prende la palla da 9
+il giocatore 9 prende la palla da 0
+il giocatore 2 prende la palla da 9
+il giocatore 9 prende la palla da 2
+il giocatore 9 scarta il giocatore 3
+il giocatore 9 scarta il giocatore 4
+il giocatore 9 tira... e ha mancato la porta...
+il giocatore 1 e' vittima di un infortunio da parte di 8
+il giocatore 7 prende la palla da 3
+il giocatore 4 prende la palla da 7
+il giocatore 4 scarta il giocatore 9
+il giocatore 7 prende la palla da 4
+il giocatore 7 scarta il giocatore 0
+il giocatore 7 scarta il giocatore 2
+il giocatore 7 tira... e ha mancato la porta...
+il giocatore 2 scarta il giocatore 9
+il giocatore 2 e' vittima di un infortunio da parte di 8
+il giocatore 6 prende la palla da 0
+il giocatore 6 scarta il giocatore 0
+il giocatore 6 scarta il giocatore 1
+il giocatore 6 scarta il giocatore 3
+il giocatore 6 tira... ed e' GOAL!!!
+il giocatore 1 scarta il giocatore 9
+il giocatore 1 tira... e ha mancato la porta...
+il giocatore 5 scarta il giocatore 1
+il giocatore 5 scarta il giocatore 3
+il giocatore 5 tira... ed e' GOAL!!!
+il giocatore 8 prende la palla da 1
+il giocatore 8 scarta il giocatore 1
+il giocatore 8 scarta il giocatore 1
+il giocatore 8 scarta il giocatore 1
+il giocatore 8 tira... ed e' GOAL!!!
+il giocatore 8 prende la palla da 3
+il giocatore 8 scarta il giocatore 3
+il giocatore 0 prende la palla da 8
+il giocatore 0 scarta il giocatore 6
+il giocatore 0 tira... ed e' GOAL!!!
+il giocatore 5 scarta il giocatore 2
+il giocatore 4 prende la palla da 5
+il giocatore 4 scarta il giocatore 8
+il giocatore 4 tira... ed e' GOAL!!!
+il giocatore 3 prende la palla da 7
+il giocatore 7 prende la palla da 3
+il giocatore 7 scarta il giocatore 0
+il giocatore 7 scarta il giocatore 0
+il giocatore 7 scarta il giocatore 3
+il giocatore 7 tira... ed e' GOAL!!!
+il giocatore 0 scarta il giocatore 5
+il giocatore 0 scarta il giocatore 7
+il giocatore 0 tira... e ha mancato la porta...
+il giocatore 3 prende la palla da 6
+il giocatore 3 scarta il giocatore 5
+il giocatore 3 scarta il giocatore 5
+il giocatore 3 scarta il giocatore 6
+il giocatore 3 tira... e ha mancato la porta...
+il giocatore 1 prende la palla da 7
+il giocatore 1 scarta il giocatore 9
+il giocatore 1 tira... e ha mancato la porta...
+il giocatore 0 prende la palla da 5
+il giocatore 9 prende la palla da 0
+il giocatore 9 scarta il giocatore 0
+il giocatore 9 tira... ed e' GOAL!!!
+il giocatore 0 scarta il giocatore 7
+il giocatore 5 prende la palla da 0
+il giocatore 0 prende la palla da 5
+il giocatore 0 scarta il giocatore 7
+il giocatore 0 scarta il giocatore 6
+il giocatore 0 scarta il giocatore 9
+il giocatore 0 tira... e ha mancato la porta...
+il giocatore 3 prende la palla da 6
+il giocatore 3 scarta il giocatore 5
+il giocatore 3 tira... ed e' GOAL!!!
+il giocatore 9 scarta il giocatore 1
+il giocatore 9 scarta il giocatore 2
+il giocatore 9 tira... e ha mancato la porta...
+il giocatore 8 prende la palla da 4
+il giocatore 8 scarta il giocatore 3
+il giocatore 8 tira... ed e' GOAL!!!
+il giocatore 3 scarta il giocatore 8
+il giocatore 3 scarta il giocatore 7
+il giocatore 3 tira... e ha mancato la porta...
+il giocatore 8 scarta il giocatore 4
+il giocatore 8 tira... e ha mancato la porta...
+il giocatore 4 scarta il giocatore 6
+il giocatore 4 tira... e ha mancato la porta...
+il giocatore 0 prende la palla da 5
+il giocatore 5 prende la palla da 0
+il giocatore 3 prende la palla da 5
+il giocatore 3 scarta il giocatore 7
+il giocatore 7 prende la palla da 3
+il giocatore 2 prende la palla da 7
+il giocatore 6 prende la palla da 2
+il giocatore 6 scarta il giocatore 2
+il giocatore 6 tira... ed e' GOAL!!!
+il giocatore 0 scarta il giocatore 7
+il giocatore 0 tira... ed e' GOAL!!!
+il giocatore 8 scarta il giocatore 2
+il giocatore 8 tira... e ha mancato la porta...
+il giocatore 5 prende la palla da 4
+il giocatore 3 prende la palla da 5
+il giocatore 3 scarta il giocatore 5
+il giocatore 8 prende la palla da 3
+il giocatore 8 scarta il giocatore 4
+il giocatore 4 prende la palla da 8
+il giocatore 9 prende la palla da 4
+il giocatore 9 scarta il giocatore 3
+il giocatore 9 tira... ed e' GOAL!!!
+il giocatore 1 scarta il giocatore 9
+il giocatore 1 tira... ed e' GOAL!!!
+il giocatore 1 prende la palla da 9
+il giocatore 1 scarta il giocatore 6
+il giocatore 1 scarta il giocatore 7
+il giocatore 8 prende la palla da 1
+il giocatore 0 prende la palla da 8
+il giocatore 0 scarta il giocatore 6
+il giocatore 0 scarta il giocatore 7
+il giocatore 0 tira... ed e' GOAL!!!
+il giocatore 5 scarta il giocatore 4
+il giocatore 5 scarta il giocatore 3
+il giocatore 5 scarta il giocatore 2
+il giocatore 2 prende la palla da 5
+il giocatore 2 scarta il giocatore 6
+il giocatore 2 scarta il giocatore 7
+il giocatore 2 e' vittima di un infortunio da parte di 9
+il giocatore 1 scarta il giocatore 6
+il giocatore 1 scarta il giocatore 5
+il giocatore 6 prende la palla da 1
+il giocatore 3 prende la palla da 6
+il giocatore 3 scarta il giocatore 8
+il giocatore 3 tira... ed e' GOAL!!!
+il giocatore 8 scarta il giocatore 1
+il giocatore 0 prende la palla da 8
+il giocatore 0 scarta il giocatore 7
+il giocatore 0 tira... e ha mancato la porta...
+il giocatore 9 scarta il giocatore 1
+il giocatore 9 scarta il giocatore 2
+il giocatore 9 tira... ed e' GOAL!!!
+il giocatore 4 scarta il giocatore 8
+il giocatore 6 prende la palla da 4
+il giocatore 0 prende la palla da 6
+il giocatore 0 scarta il giocatore 5
+il giocatore 0 scarta il giocatore 9
+il giocatore 0 tira... e ha mancato la porta...
+il giocatore 1 prende la palla da 9
+il giocatore 1 e' vittima di un infortunio da parte di 7
+il giocatore 8 prende la palla da 0
+il giocatore 3 prende la palla da 8
+il giocatore 8 prende la palla da 3
+il giocatore 2 prende la palla da 8
+il giocatore 5 prende la palla da 2
+il giocatore 3 prende la palla da 5
+il giocatore 3 scarta il giocatore 6
+il giocatore 3 e' vittima di un infortunio da parte di 6
+il giocatore 4 scarta il giocatore 9
+il giocatore 5 prende la palla da 4
+il giocatore 2 prende la palla da 5
+il giocatore 2 scarta il giocatore 8
+il giocatore 2 scarta il giocatore 9
+il giocatore 8 prende la palla da 2
+il giocatore 8 scarta il giocatore 1
+il giocatore 8 scarta il giocatore 0
+il giocatore 8 tira... e ha mancato la porta...
+il giocatore 7 prende la palla da 2
+il giocatore 1 prende la palla da 7
+il giocatore 1 scarta il giocatore 7
+il giocatore 1 scarta il giocatore 8
+il giocatore 5 prende la palla da 1
+il giocatore 1 prende la palla da 5
+il giocatore 1 scarta il giocatore 9
+il giocatore 1 e' vittima di un infortunio da parte di 8
+il giocatore 3 scarta il giocatore 5
+il giocatore 3 scarta il giocatore 5
+il giocatore 3 scarta il giocatore 5
+il giocatore 3 tira... ed e' GOAL!!!
+il giocatore 2 prende la palla da 9
+il giocatore 6 prende la palla da 2
+il giocatore 6 scarta il giocatore 4
+il giocatore 4 prende la palla da 6
+il giocatore 4 scarta il giocatore 8
+il giocatore 5 prende la palla da 4
+il giocatore 5 scarta il giocatore 4
+il giocatore 2 prende la palla da 5
+il giocatore 2 scarta il giocatore 8
+il giocatore 2 scarta il giocatore 6
+il giocatore 2 tira... ed e' GOAL!!!
+il giocatore 9 e' vittima di un infortunio da parte di 1
+il giocatore 3 prende la palla da 6
+il giocatore 3 scarta il giocatore 6
+il giocatore 5 prende la palla da 3
+il giocatore 5 scarta il giocatore 3
+il giocatore 2 prende la palla da 5
+il giocatore 2 scarta il giocatore 5
+il giocatore 5 prende la palla da 2
+il giocatore 3 prende la palla da 5
+il giocatore 5 prende la palla da 3
+il giocatore 1 prende la palla da 5
+il giocatore 1 scarta il giocatore 5
+il giocatore 1 scarta il giocatore 5
+il giocatore 1 tira... ed e' GOAL!!!
+il giocatore 5 scarta il giocatore 2
+il giocatore 0 prende la palla da 5
+il giocatore 8 prende la palla da 0
+il giocatore 0 prende la palla da 8
+il giocatore 9 prende la palla da 0
+il giocatore 9 scarta il giocatore 3
+il giocatore 2 prende la palla da 9
+il giocatore 2 scarta il giocatore 5
+il giocatore 2 e' vittima di un infortunio da parte di 9
+il giocatore 3 scarta il giocatore 6
+il giocatore 5 prende la palla da 3
+il giocatore 5 scarta il giocatore 1
+il giocatore 5 scarta il giocatore 0
+il giocatore 5 tira... e ha mancato la porta...
+il giocatore 3 scarta il giocatore 5
+il giocatore 3 scarta il giocatore 8
+il giocatore 3 tira... ed e' GOAL!!!
+il giocatore 3 prende la palla da 9
+il giocatore 6 prende la palla da 3
+il giocatore 6 scarta il giocatore 3
+il giocatore 6 scarta il giocatore 2
+il giocatore 4 prende la palla da 6
+il giocatore 4 scarta il giocatore 6
+il giocatore 4 scarta il giocatore 7
+il giocatore 4 scarta il giocatore 9
+il giocatore 4 tira... e ha mancato la porta...
+il giocatore 8 scarta il giocatore 4
+il giocatore 8 scarta il giocatore 0
+il giocatore 8 scarta il giocatore 0
+il giocatore 8 tira... e ha mancato la porta...
+il giocatore 1 scarta il giocatore 9
+il giocatore 1 scarta il giocatore 5
+il giocatore 1 scarta il giocatore 6
+il giocatore 1 tira... e ha mancato la porta...
+il giocatore 0 prende la palla da 5
+il giocatore 0 scarta il giocatore 9
+il giocatore 0 tira... e ha mancato la porta...
+il giocatore 9 scarta il giocatore 3
+il giocatore 4 prende la palla da 9
+il giocatore 4 scarta il giocatore 6
+il giocatore 4 tira... ed e' GOAL!!!
+il giocatore 0 prende la palla da 5
+il giocatore 0 scarta il giocatore 7
+il giocatore 0 scarta il giocatore 5
+il giocatore 0 tira... ed e' GOAL!!!
+il giocatore 3 prende la palla da 6
+il giocatore 6 prende la palla da 3
+il giocatore 6 scarta il giocatore 2
+il giocatore 6 tira... e ha mancato la porta...
+il giocatore 2 scarta il giocatore 7
+il giocatore 2 scarta il giocatore 6
+il giocatore 8 prende la palla da 2
+il giocatore 8 scarta il giocatore 1
+il giocatore 8 scarta il giocatore 4
+il giocatore 8 scarta il giocatore 4
+il giocatore 8 tira... ed e' GOAL!!!
+il giocatore 8 prende la palla da 3
+il giocatore 8 scarta il giocatore 0
+il giocatore 8 tira... ed e' GOAL!!!
+il giocatore 3 scarta il giocatore 8
+il giocatore 8 prende la palla da 3
+il giocatore 8 scarta il giocatore 3
+il giocatore 8 tira... ed e' GOAL!!!
+il giocatore 1 scarta il giocatore 7
+il giocatore 1 scarta il giocatore 6
+il giocatore 1 tira... e ha mancato la porta...
+il giocatore 5 scarta il giocatore 4
+il giocatore 0 prende la palla da 5
+il giocatore 0 scarta il giocatore 6
+il giocatore 0 scarta il giocatore 9
+il giocatore 9 prende la palla da 0
+il giocatore 9 scarta il giocatore 1
+il giocatore 9 scarta il giocatore 3
+il giocatore 9 tira... e ha mancato la porta...
+il giocatore 0 scarta il giocatore 5
+il giocatore 5 prende la palla da 0
+il giocatore 5 scarta il giocatore 4
+il giocatore 2 prende la palla da 5
+il giocatore 2 scarta il giocatore 8
+il giocatore 2 tira... e ha mancato la porta...
+il giocatore 9 scarta il giocatore 0
+il giocatore 9 scarta il giocatore 3
+il giocatore 9 tira... ed e' GOAL!!!
+il giocatore 4 scarta il giocatore 5
+il giocatore 4 tira... ed e' GOAL!!!
+il giocatore 7 scarta il giocatore 1
+il giocatore 7 tira... e ha mancato la porta...
+il giocatore 9 prende la palla da 2
+il giocatore 9 scarta il giocatore 1
+il giocatore 9 scarta il giocatore 1
+il giocatore 9 tira... ed e' GOAL!!!
+il giocatore 0 scarta il giocatore 8
+il giocatore 8 prende la palla da 0
+il giocatore 1 prende la palla da 8
+il giocatore 6 prende la palla da 1
+il giocatore 0 prende la palla da 6
+il giocatore 7 prende la palla da 0

--- a/tiro/tiro.c
+++ b/tiro/tiro.c
@@ -58,16 +58,27 @@ void* service(void *arg){
 	resolve_hostname("gateway", ip, sizeof(ip));
 
 	recv(s_fd, buffer, BUFDIM, 0);
-	if (strcmp(buffer, "partita terminata\0") == 0) {
+	if (buffer[0] == 't') {
 		stop = 0;
-		pthread_exit(NULL);
+		exit(1);
 	}
-	send(s_fd, NULL, 0, 0);
-	close(s_fd);
+	char buf[BUFDIM];
+	
 
 	printf("service: from player buffer = %s\n",buffer);
 	player = buffer[0] - '0';
 
+	if (player < 0 || player > 9) {
+		printf("service: wrong buffer %s\n", buffer);
+
+		snprintf(buf, BUFDIM, "err\0");
+		send(s_fd, buf, BUFDIM, 0);
+		//close(s_fd);
+		pthread_mutex_unlock(&synchro);
+		pthread_exit(NULL);
+	}
+	snprintf(buf, BUFDIM, "ack\0");
+	send(s_fd, buf, BUFDIM, 0);
 
 	chance = rand() % 100;
 	if(chance < 50){
@@ -91,7 +102,7 @@ void* service(void *arg){
 	send(client_fd, buffer, BUFDIM, 0);
 	printf("service: to referee buffer = %s\n", buffer);
 	
-	close(client_fd);
+	//close(client_fd);
 	pthread_mutex_unlock(&synchro);
 }
 

--- a/tiro/tiro.c
+++ b/tiro/tiro.c
@@ -139,8 +139,6 @@ int main(int argc, char* argv[]) {
 		client = accept(serverSocket, (struct sockaddr*)&clientAddr, &len);
 		printf("main: player accepted!\n");
 		pthread_create(&player, NULL, service, (void*)&client);
-		printf("main: player stopped\n");
-        pthread_join(player, NULL);
 	}
 
 	return 0;

--- a/tiro/tiro.c
+++ b/tiro/tiro.c
@@ -13,7 +13,7 @@
 #define PORT 8077
 #define BUFDIM 1024
 #define REFEREEPORT 8088
-#define QUEUE 90
+#define QUEUE 360
 
 volatile short stop = -1;
 

--- a/tiro/tiro.c
+++ b/tiro/tiro.c
@@ -24,13 +24,17 @@ void* service(void *arg){
 
 	struct hostent* hent;
 	hent = gethostbyname("gateway");
+	if (hent == NULL) {
+		perror("gethostbyname");
+		pthread_exit(NULL); // Exit the thread if gethostbyname fails
+	}
 	char ip[40];
 	inet_ntop(AF_INET, (void*)hent->h_addr_list[0], ip, 15);
 
 	read(s_fd, buffer, BUFDIM);
 	if (strcmp(buffer, "partita terminata\0") == 0) {
 		stop = 0;
-		exit(1);
+		pthread_exit(NULL);
 	}
 	printf("service: from player buffer = %s\n",buffer);
 	player = buffer[0] - '0';
@@ -40,11 +44,11 @@ void* service(void *arg){
 	if(chance < 50){
 		//fallito
 		//  t%d(r)\0
-        sprintf(buffer, "t%df\0", player);
+        snprintf(buffer, BUFDIM, "t%df\0", player);
 	}else{
 		//goal
 		//  t%d(r)\0
-        sprintf(buffer, "t%dy\0", player);
+        snprintf(buffer, BUFDIM, "t%dy\0", player);
 	}
 
     client_fd = socket(AF_INET, SOCK_STREAM, 0);
@@ -77,6 +81,10 @@ int main(int argc, char* argv[]) {
 	gethostname(hostname, 1023);
 	struct hostent* hent;
 	hent = gethostbyname(hostname);
+	if (hent == NULL) {
+		perror("gethostbyname");
+		exit(1); // Exit the thread if gethostbyname fails
+	}
 	char ip[40];
 	inet_ntop(AF_INET, (void*)hent->h_addr_list[0], ip, 15);
 

--- a/tiro/tiro.c
+++ b/tiro/tiro.c
@@ -12,7 +12,7 @@
 
 #define PORT 8077
 #define BUFDIM 1024
-#define REFEREEPORT 8088 
+#define REFEREEPORT 8088
 
 volatile short stop = -1;
 
@@ -39,7 +39,7 @@ void* service(void *arg){
 	printf("service: from player buffer = %s\n",buffer);
 	player = buffer[0] - '0';
 
-	
+
 	chance = rand() % 100;
 	if(chance < 50){
 		//fallito
@@ -58,12 +58,12 @@ void* service(void *arg){
     if (connect(client_fd, (struct sockaddr*)&client_addr, sizeof(client_addr))) {
 		printf("connect() failed to %s:%d\n", ip, REFEREEPORT);
 	}
-    
+
 	write(client_fd, buffer, BUFDIM);
 	printf("service: to referee buffer = %s\n", buffer);
 
 	close(client_fd);
-	
+
 }
 
 int main(int argc, char* argv[]) {
@@ -101,9 +101,9 @@ int main(int argc, char* argv[]) {
 	inet_ntop(AF_INET, &serverAddr.sin_addr, buf, sizeof(buf));
 
 	printf("Accepting as %s:%d...\n", buf, PORT);
-	
+
 	int i = 0, j = 0;
-	
+
 	while (i < 5 || j < 5){
 		client = accept(serverSocket, (struct sockaddr*)&clientAddr, &len);
 		read(client, buffer, BUFDIM);
@@ -118,7 +118,7 @@ int main(int argc, char* argv[]) {
 			j++;
 		}
 	}
-    
+
 	while(stop == -1){
 		printf("main: accepting player...\n");
 		client = accept(serverSocket, (struct sockaddr*)&clientAddr, &len);

--- a/tiro/tiro.c
+++ b/tiro/tiro.c
@@ -13,23 +13,44 @@
 #define PORT 8077
 #define BUFDIM 1024
 #define REFEREEPORT 8088
+#define QUEUE 90
 
 volatile short stop = -1;
+
+void resolve_hostname(const char* hostname, char* ip, size_t ip_len) {
+	struct addrinfo hints, * res;
+	int errcode;
+	void* ptr;
+
+	memset(&hints, 0, sizeof(hints));
+	hints.ai_family = AF_INET; // For IPv4
+	hints.ai_socktype = SOCK_STREAM;
+	hints.ai_flags = 0;
+
+	errcode = getaddrinfo(hostname, NULL, &hints, &res);
+	if (errcode != 0) {
+		fprintf(stderr, "getaddrinfo: %s\n", gai_strerror(errcode));
+		pthread_exit(NULL);
+	}
+
+	ptr = &((struct sockaddr_in*)res->ai_addr)->sin_addr;
+
+	if (inet_ntop(res->ai_family, ptr, ip, ip_len) == NULL) {
+		perror("inet_ntop");
+		freeaddrinfo(res);
+		pthread_exit(NULL);
+	}
+
+	freeaddrinfo(res);
+}
 
 void* service(void *arg){
 	char buffer[BUFDIM];
     int s_fd, player, chance, client_fd;
 	struct sockaddr_in client_addr;
 	s_fd = *(int*)arg;
-
-	struct hostent* hent;
-	hent = gethostbyname("gateway");
-	if (hent == NULL) {
-		perror("gethostbyname");
-		pthread_exit(NULL); // Exit the thread if gethostbyname fails
-	}
 	char ip[40];
-	inet_ntop(AF_INET, (void*)hent->h_addr_list[0], ip, 15);
+	resolve_hostname("gateway", ip, sizeof(ip));
 
 	read(s_fd, buffer, BUFDIM);
 	if (strcmp(buffer, "partita terminata\0") == 0) {
@@ -79,14 +100,8 @@ int main(int argc, char* argv[]) {
 
 	char hostname[1023] = { '\0' };
 	gethostname(hostname, 1023);
-	struct hostent* hent;
-	hent = gethostbyname(hostname);
-	if (hent == NULL) {
-		perror("gethostbyname");
-		exit(1); // Exit the thread if gethostbyname fails
-	}
 	char ip[40];
-	inet_ntop(AF_INET, (void*)hent->h_addr_list[0], ip, 15);
+	resolve_hostname(hostname, ip, sizeof(ip));
 
     serverSocket = socket(AF_INET, SOCK_STREAM, 0);
 	serverAddr.sin_family = AF_INET;
@@ -95,7 +110,7 @@ int main(int argc, char* argv[]) {
 	memset(&(serverAddr.sin_zero), '\0', 8);
 
     bind(serverSocket, (struct sockaddr*)&serverAddr, sizeof(serverAddr));
-	listen(serverSocket, 12);
+	listen(serverSocket, QUEUE);
 
 	char buf[INET_ADDRSTRLEN];
 	inet_ntop(AF_INET, &serverAddr.sin_addr, buf, sizeof(buf));


### PR DESCRIPTION
Attraverso la separazione delle procedure dell'arbitro con l'uso di `fork()` e quindi di un processo in concorrenza, si evita l'errore per cui i socket descriptor vengono mescolati alla ricezione.
Implementando meccanismi di sincronizzazione tra client e server tutti gli eventi vengono mandati correttamente ed in ordine al thread arbitro del client.
Meccanismi simili sono stati utilizzati per la comunicazione tra gateway e i vari servizi.